### PR TITLE
HNS configurable from command line

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -23,12 +23,12 @@ type ContrailDriver struct {
 	HnsID string
 }
 
-func NewDriver() (*ContrailDriver, error) {
+func NewDriver(subnet, gateway, adapter string) (*ContrailDriver, error) {
 
 	subnets := []hcsshim.Subnet{
 		{
-			AddressPrefix:  "172.117.0.0/16",
-			GatewayAddress: "172.117.0.1",
+			AddressPrefix:  subnet,
+			GatewayAddress: gateway,
 		},
 	}
 
@@ -36,7 +36,7 @@ func NewDriver() (*ContrailDriver, error) {
 		Name:               NetworkHNSname,
 		Type:               "transparent",
 		Subnets:            subnets,
-		NetworkAdapterName: "Ethernet0",
+		NetworkAdapterName: adapter,
 	}
 
 	hnsID, err := CreateHNSNetwork(configuration)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/codilime/contrail-windows-docker/driver"
 	"github.com/docker/go-plugins-helpers/network"
@@ -8,8 +10,16 @@ import (
 )
 
 func main() {
-	d, err := driver.NewDriver()
-	if err != nil {
+	var subnet = flag.String("subnet", "172.117.0.0/16", "subnet in CIDR format for HNS")
+	var gateway = flag.String("gateway", "172.117.0.1", "default gateway IP for HNS")
+	var adapter = flag.String("adapter", "Ethernet0",
+		"net adapter for HNS switch, must be physical")
+	flag.Parse()
+
+	var d *driver.ContrailDriver
+	var err error
+
+	if d, err = driver.NewDriver(*subnet, *gateway, *adapter); err != nil {
 		logrus.Error(err)
 	}
 	h := network.NewHandler(d)

--- a/tests/driver_test.go
+++ b/tests/driver_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Contrail Network Driver", func() {
 })
 
 func startDriver() *driver.ContrailDriver {
-	d, err := driver.NewDriver()
+	d, err := driver.NewDriver("172.100.0.0/16", "172.100.0.1", "Ethernet0")
 	Expect(err).ToNot(HaveOccurred())
 	Expect(d.HnsID).ToNot(Equal(""))
 	return d


### PR DESCRIPTION
Lets specify hns network, gateway, and which net adapter to use as command line arguments.