### PR TITLE
Improve tests (+refactor project struct)

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -1,0 +1,12 @@
+package common
+
+const (
+	// DomainName specifies domain name in Contrail
+	DomainName = "default-domain"
+
+	// DriverName is name of the driver that is to be specified during docker network creation
+	DriverName = "Contrail"
+
+	// HNSNetworkName is a constant name for HNS network
+	NetworkHNSname = "ContrailHNSNet"
+)

--- a/common/misc.go
+++ b/common/misc.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"os/exec"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func HardResetHNS() error {
+	log.Debugln("Removing container networks")
+	if err := exec.Command("powershell", "Get-ContainerNetwork", "|",
+		"Remove-ContainerNetwork").Run(); err != nil {
+		log.Debugln("Could not remove container network.")
+	}
+	log.Debugln("Stopping HNS")
+	if err := exec.Command("powershell", "Stop-Service", "hns").Run(); err != nil {
+		log.Debugln("HNS is already stopped.")
+	}
+	log.Debugln("Removing HNS program data")
+	if err := exec.Command("powershell", "Remove-Item",
+		"C:\\ProgramData\\Microsoft\\Windows\\HNS\\HNS.data").Run(); err != nil {
+		return err
+	}
+	log.Debugln("Starting HNS")
+	if err := exec.Command("powershell", "Start-Service", "hns").Run(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1,4 +1,4 @@
-package driver
+package controller
 
 import (
 	"errors"
@@ -6,10 +6,7 @@ import (
 
 	"github.com/Juniper/contrail-go-api"
 	"github.com/Juniper/contrail-go-api/types"
-)
-
-const (
-	DomainName = "default-domain"
+	"github.com/codilime/contrail-windows-docker/common"
 )
 
 type Info struct {
@@ -27,7 +24,7 @@ func NewController(ip string, port int) *Controller {
 
 func (c *Controller) GetNetwork(tenantName, networkName string) (*types.VirtualNetwork,
 	error) {
-	name := fmt.Sprintf("%s:%s:%s", DomainName, tenantName, networkName)
+	name := fmt.Sprintf("%s:%s:%s", common.DomainName, tenantName, networkName)
 	net, err := types.VirtualNetworkByName(c.ApiClient, name)
 	if err != nil {
 		return nil, err
@@ -56,14 +53,14 @@ func (c *Controller) GetDefaultGatewayIp(net *types.VirtualNetwork) (string, err
 }
 
 func (c *Controller) GetOrCreateInstance(tenantName, containerId string) (*types.VirtualMachine, error) {
-	name := fmt.Sprintf("%s:%s:%s", DomainName, tenantName, containerId)
+	name := fmt.Sprintf("%s:%s:%s", common.DomainName, tenantName, containerId)
 	instance, err := types.VirtualMachineByName(c.ApiClient, name)
 	if err == nil && instance != nil {
 		return instance, nil
 	}
 
 	instance = new(types.VirtualMachine)
-	instance.SetFQName("project", []string{DomainName, tenantName, containerId})
+	instance.SetFQName("project", []string{common.DomainName, tenantName, containerId})
 	err = c.ApiClient.Create(instance)
 	if err != nil {
 		return nil, err
@@ -75,14 +72,14 @@ func (c *Controller) GetOrCreateInterface(net *types.VirtualNetwork,
 	instance *types.VirtualMachine) (*types.VirtualMachineInterface, error) {
 	instanceFQName := instance.GetFQName()
 	namespace := instanceFQName[len(instanceFQName)-2]
-	name := fmt.Sprintf("%s:%s:%s", DomainName, namespace, instance.GetName())
+	name := fmt.Sprintf("%s:%s:%s", common.DomainName, namespace, instance.GetName())
 	iface, err := types.VirtualMachineInterfaceByName(c.ApiClient, name)
 	if err == nil && iface != nil {
 		return iface, nil
 	}
 
 	iface = new(types.VirtualMachineInterface)
-	iface.SetFQName("project", []string{DomainName, namespace, instance.GetName()})
+	iface.SetFQName("project", []string{common.DomainName, namespace, instance.GetName()})
 	err = iface.AddVirtualMachine(instance)
 	if err != nil {
 		return nil, err

--- a/controller/controller_test_helpers.go
+++ b/controller/controller_test_helpers.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"fmt"
+
+	contrail "github.com/Juniper/contrail-go-api"
+	"github.com/Juniper/contrail-go-api/config"
+	"github.com/Juniper/contrail-go-api/mocks"
+	"github.com/Juniper/contrail-go-api/types"
+	"github.com/codilime/contrail-windows-docker/common"
+	. "github.com/onsi/gomega"
+)
+
+func NewMockedClientAndProject(tenant string) (*Controller, *types.Project) {
+	c := &Controller{}
+	mockedApiClient := new(mocks.ApiClient)
+	mockedApiClient.Init()
+	c.ApiClient = mockedApiClient
+
+	project := new(types.Project)
+	project.SetFQName("domain", []string{common.DomainName, tenant})
+	err := c.ApiClient.Create(project)
+	Expect(err).ToNot(HaveOccurred())
+	return c, project
+}
+
+func CreateMockedNetworkWithSubnet(c contrail.ApiClient, netName, subnetCIDR string,
+	project *types.Project) *types.VirtualNetwork {
+	netUUID, err := config.CreateNetworkWithSubnet(c, project.GetUuid(), netName, subnetCIDR)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(netUUID).ToNot(BeNil())
+	testNetwork, err := types.VirtualNetworkByUuid(c, netUUID)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(testNetwork).ToNot(BeNil())
+	return testNetwork
+}
+
+func CreateMockedNetwork(c contrail.ApiClient, netName string,
+	project *types.Project) *types.VirtualNetwork {
+	netUUID, err := config.CreateNetwork(c, project.GetUuid(), netName)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(netUUID).ToNot(BeNil())
+	testNetwork, err := types.VirtualNetworkByUuid(c, netUUID)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(testNetwork).ToNot(BeNil())
+	return testNetwork
+}
+
+func AddSubnetWithDefaultGateway(c contrail.ApiClient, subnetPrefix, defaultGW string,
+	subnetMask int, testNetwork *types.VirtualNetwork) {
+	subnet := &types.IpamSubnetType{
+		Subnet:         &types.SubnetType{IpPrefix: subnetPrefix, IpPrefixLen: subnetMask},
+		DefaultGateway: defaultGW,
+	}
+
+	var ipamSubnets types.VnSubnetsType
+	ipamSubnets.AddIpamSubnets(subnet)
+
+	ipam, err := c.FindByName("network-ipam",
+		"default-domain:default-project:default-network-ipam")
+	Expect(err).ToNot(HaveOccurred())
+	err = testNetwork.AddNetworkIpam(ipam.(*types.NetworkIpam), ipamSubnets)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = c.Update(testNetwork)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func CreateMockedInstance(c contrail.ApiClient, tenantName,
+	containerID string) *types.VirtualMachine {
+	testInstance := new(types.VirtualMachine)
+	testInstance.SetFQName("project", []string{common.DomainName, tenantName, containerID})
+	err := c.Create(testInstance)
+	Expect(err).ToNot(HaveOccurred())
+	return testInstance
+}
+
+func CreateMockedInterface(c contrail.ApiClient, instance *types.VirtualMachine,
+	net *types.VirtualNetwork) *types.VirtualMachineInterface {
+	iface := new(types.VirtualMachineInterface)
+	instanceFQName := instance.GetFQName()
+	namespace := instanceFQName[len(instanceFQName)-2]
+	iface.SetFQName("project", []string{common.DomainName, namespace, instance.GetName()})
+	err := iface.AddVirtualMachine(instance)
+	Expect(err).ToNot(HaveOccurred())
+	err = iface.AddVirtualNetwork(net)
+	Expect(err).ToNot(HaveOccurred())
+	err = c.Create(iface)
+	Expect(err).ToNot(HaveOccurred())
+	return iface
+}
+
+func AddMacToInterface(c contrail.ApiClient, ifaceMac string,
+	iface *types.VirtualMachineInterface) {
+	macs := new(types.MacAddressesType)
+	macs.AddMacAddress(ifaceMac)
+	iface.SetVirtualMachineInterfaceMacAddresses(macs)
+	err := c.Update(iface)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func CreateMockedInstanceIP(c contrail.ApiClient, tenantName string,
+	iface *types.VirtualMachineInterface,
+	net *types.VirtualNetwork) *types.InstanceIp {
+	name := fmt.Sprintf("%s_%s", tenantName, iface.GetName())
+
+	instIP := &types.InstanceIp{}
+	instIP.SetName(name)
+	err := instIP.AddVirtualNetwork(net)
+	Expect(err).ToNot(HaveOccurred())
+	err = instIP.AddVirtualMachineInterface(iface)
+	Expect(err).ToNot(HaveOccurred())
+	err = c.Create(instIP)
+	Expect(err).ToNot(HaveOccurred())
+
+	allocatedIP, err := types.InstanceIpByUuid(c, instIP.GetUuid())
+	Expect(err).ToNot(HaveOccurred())
+	return allocatedIP
+}

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,10 +1,11 @@
-package test
+package driver
 
 import (
 	"testing"
 	"time"
 
-	"github.com/codilime/contrail-windows-docker/driver"
+	"github.com/codilime/contrail-windows-docker/common"
+	"github.com/codilime/contrail-windows-docker/hns"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-plugins-helpers/network"
 	. "github.com/onsi/ginkgo"
@@ -16,35 +17,44 @@ func TestDriver(t *testing.T) {
 	RunSpecs(t, "Contrail Network Driver test suite")
 }
 
+var _ = BeforeSuite(func() {
+	err := common.HardResetHNS()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	err := common.HardResetHNS()
+	Expect(err).ToNot(HaveOccurred())
+})
+
 var _ = Describe("Contrail Network Driver", func() {
 
-	contrailDriver := &driver.ContrailDriver{}
+	contrailDriver := &ContrailDriver{}
 
 	Context("upon starting", func() {
 
-		It("listens on a pipe", func() {
+		PIt("listens on a pipe", func() {
 			d := startDriver()
 			defer stopDriver(d)
 
-			Skip("TODO")
-			_, err := sockets.DialPipe("//./pipe/"+driver.DriverName, time.Second*3)
+			_, err := sockets.DialPipe("//./pipe/"+common.DriverName, time.Second*3)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("tries to connect to existing HNS switch", func() {
+		PIt("tries to connect to existing HNS switch", func() {
 			d := startDriver()
 			defer stopDriver(d)
 		})
 
 		It("if HNS switch doesn't exist, creates a new one", func() {
-			net, err := driver.GetHNSNetworkByName(driver.NetworkHNSname)
+			net, err := hns.GetHNSNetworkByName(common.NetworkHNSname)
 			Expect(net).To(BeNil())
 			Expect(err).To(HaveOccurred())
 
 			d := startDriver()
 			defer stopDriver(d)
 
-			net, err = driver.GetHNSNetworkByName(driver.NetworkHNSname)
+			net, err = hns.GetHNSNetworkByName(common.NetworkHNSname)
 			Expect(net).ToNot(BeNil())
 			Expect(net.Id).To(Equal(d.HnsID))
 			Expect(err).ToNot(HaveOccurred())
@@ -54,27 +64,27 @@ var _ = Describe("Contrail Network Driver", func() {
 
 	Describe("allocating resources in Contrail Controller", func() {
 
-		Context("given correct tenant and subnet id", func() {
+		PContext("given correct tenant and subnet id", func() {
 			It("works", func() {})
 		})
 
-		Context("given incorrect tenant and subnet id", func() {
+		PContext("given incorrect tenant and subnet id", func() {
 			It("returns proper error message", func() {})
 		})
 
 	})
 
 	Context("upon shutting down", func() {
-		It("HNS switch isn't removed", func() {})
+		PIt("HNS switch isn't removed", func() {})
 	})
 
 	Describe("allocating resources in Contrail Controller", func() {
 
-		Context("given correct tenant and subnet id", func() {
+		PContext("given correct tenant and subnet id", func() {
 			It("works", func() {})
 		})
 
-		Context("given incorrect tenant and subnet id", func() {
+		PContext("given incorrect tenant and subnet id", func() {
 			It("returns proper error message", func() {})
 		})
 
@@ -90,7 +100,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on CreateNetwork", func() {
+		PContext("on CreateNetwork", func() {
 
 			Context("tenant or subnet don't exist in Contrail", func() {
 				It("responds with error", func() {})
@@ -101,7 +111,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on AllocateNetwork", func() {
+		PContext("on AllocateNetwork", func() {
 			It("responds with empty AllocateNetworkResponse, nil", func() {
 				req := network.AllocateNetworkRequest{}
 				resp, err := contrailDriver.AllocateNetwork(&req)
@@ -110,7 +120,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on DeleteNetwork", func() {
+		PContext("on DeleteNetwork", func() {
 			It("responds with nil", func() {
 				req := network.DeleteNetworkRequest{}
 				err := contrailDriver.DeleteNetwork(&req)
@@ -118,7 +128,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on FreeNetwork", func() {
+		PContext("on FreeNetwork", func() {
 			It("responds with nil", func() {
 				req := network.FreeNetworkRequest{}
 				err := contrailDriver.FreeNetwork(&req)
@@ -127,9 +137,9 @@ var _ = Describe("Contrail Network Driver", func() {
 		})
 
 		Context("on CreateEndpoint", func() {
-			It("allocates Contrail resources", func() {})
-			It("configures container network via HNS", func() {})
-			It("configures vRouter agent", func() {})
+			PIt("allocates Contrail resources", func() {})
+			PIt("configures container network via HNS", func() {})
+			PIt("configures vRouter agent", func() {})
 			It("responds with proper CreateEndpointResponse, nil", func() {
 				req := network.CreateEndpointRequest{}
 				resp, err := contrailDriver.CreateEndpoint(&req)
@@ -139,8 +149,8 @@ var _ = Describe("Contrail Network Driver", func() {
 		})
 
 		Context("on DeleteEndpoint", func() {
-			It("deallocates Contrail resources", func() {})
-			It("configures vRouter Agent", func() {})
+			PIt("deallocates Contrail resources", func() {})
+			PIt("configures vRouter Agent", func() {})
 			It("responds with nil", func() {
 				req := network.DeleteEndpointRequest{}
 				err := contrailDriver.DeleteEndpoint(&req)
@@ -148,11 +158,11 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on EndpointInfo", func() {
+		PContext("on EndpointInfo", func() {
 			It("responds with proper InfoResponse", func() {})
 		})
 
-		Context("on Join", func() {
+		PContext("on Join", func() {
 			Context("queried endpoint exists", func() {
 				It("responds with proper JoinResponse", func() {}) // nil maybe?
 			})
@@ -162,7 +172,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on Leave", func() {
+		PContext("on Leave", func() {
 
 			Context("queried endpoint exists", func() {
 				It("responds with proper JoinResponse, nil", func() {})
@@ -173,7 +183,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on DiscoverNew", func() {
+		PContext("on DiscoverNew", func() {
 			It("responds with nil", func() {
 				req := network.DiscoveryNotification{}
 				err := contrailDriver.DiscoverNew(&req)
@@ -181,7 +191,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on DiscoverDelete", func() {
+		PContext("on DiscoverDelete", func() {
 			It("responds with nil", func() {
 				req := network.DiscoveryNotification{}
 				err := contrailDriver.DiscoverDelete(&req)
@@ -189,7 +199,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on ProgramExternalConnectivity", func() {
+		PContext("on ProgramExternalConnectivity", func() {
 			It("responds with nil", func() {
 				req := network.ProgramExternalConnectivityRequest{}
 				err := contrailDriver.ProgramExternalConnectivity(&req)
@@ -197,7 +207,7 @@ var _ = Describe("Contrail Network Driver", func() {
 			})
 		})
 
-		Context("on RevokeExternalConnectivity", func() {
+		PContext("on RevokeExternalConnectivity", func() {
 			It("responds with nil", func() {
 				req := network.RevokeExternalConnectivityRequest{}
 				err := contrailDriver.RevokeExternalConnectivity(&req)
@@ -208,17 +218,18 @@ var _ = Describe("Contrail Network Driver", func() {
 	})
 })
 
-func startDriver() *driver.ContrailDriver {
-	d, err := driver.NewDriver("172.100.0.0/16", "172.100.0.1", "Ethernet0")
+func startDriver() *ContrailDriver {
+	d, err := NewDriver("172.100.0.0/16", "172.100.0.1", "Ethernet0",
+		"dummy_controller_ip", 8082) // use dummy controller address because we use mocked version.
 	Expect(err).ToNot(HaveOccurred())
 	Expect(d.HnsID).ToNot(Equal(""))
 	return d
 }
 
-func stopDriver(d *driver.ContrailDriver) {
+func stopDriver(d *ContrailDriver) {
 	err := d.Teardown()
 	Expect(err).ToNot(HaveOccurred())
-	net, err := driver.GetHNSNetworkByName(driver.NetworkHNSname)
+	net, err := hns.GetHNSNetworkByName(common.NetworkHNSname)
 	Expect(net).To(BeNil())
 	Expect(err).To(HaveOccurred())
 }

--- a/hns/hns.go
+++ b/hns/hns.go
@@ -1,4 +1,4 @@
-package driver
+package hns
 
 import (
 	"encoding/json"

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -1,11 +1,11 @@
-package test
+package hns
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/codilime/contrail-windows-docker/driver"
+	"github.com/codilime/contrail-windows-docker/common"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -15,12 +15,22 @@ func TestHNS(t *testing.T) {
 	RunSpecs(t, "HNS wrapper test suite")
 }
 
+var _ = BeforeSuite(func() {
+	err := common.HardResetHNS()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	err := common.HardResetHNS()
+	Expect(err).ToNot(HaveOccurred())
+})
+
 var _ = Describe("HNS wrapper", func() {
 
 	var originalNumNetworks int
 
 	BeforeEach(func() {
-		nets, err := driver.ListHNSNetworks()
+		nets, err := ListHNSNetworks()
 		Expect(err).ToNot(HaveOccurred())
 		originalNumNetworks = len(nets)
 	})
@@ -55,27 +65,26 @@ var _ = Describe("HNS wrapper", func() {
 		BeforeEach(func() {
 			Expect(testHnsID).To(Equal(""))
 			var err error
-			testHnsID, err = driver.CreateHNSNetwork(configuration)
+			testHnsID, err = CreateHNSNetwork(configuration)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testHnsID).ToNot(Equal(""))
 		})
 
 		AfterEach(func() {
 			Expect(testHnsID).ToNot(Equal(""))
-			err := driver.DeleteHNSNetwork(testHnsID)
+			err := DeleteHNSNetwork(testHnsID)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = driver.GetHNSNetwork(testHnsID)
+			_, err = GetHNSNetwork(testHnsID)
 			Expect(err).To(HaveOccurred())
 			testHnsID = ""
-			nets, err := driver.ListHNSNetworks()
+			nets, err := ListHNSNetworks()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).ToNot(BeNil())
 			Expect(len(nets)).To(Equal(originalNumNetworks))
 		})
 
 		Specify("listing all HNS networks works", func() {
-			By("listing all HNS networks works")
-			nets, err := driver.ListHNSNetworks()
+			nets, err := ListHNSNetworks()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nets).ToNot(BeNil())
 			Expect(len(nets)).To(Equal(originalNumNetworks + 1))
@@ -90,14 +99,14 @@ var _ = Describe("HNS wrapper", func() {
 		})
 
 		Specify("getting a single HNS network works", func() {
-			net, err := driver.GetHNSNetwork(testHnsID)
+			net, err := GetHNSNetwork(testHnsID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(net).ToNot(BeNil())
 			Expect(net.Id).To(Equal(testHnsID))
 		})
 
 		Specify("getting a single HNS network by name works", func() {
-			net, err := driver.GetHNSNetworkByName(testNetName)
+			net, err := GetHNSNetworkByName(testNetName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(net).ToNot(BeNil())
 			Expect(net.Id).To(Equal(testHnsID))
@@ -107,31 +116,31 @@ var _ = Describe("HNS wrapper", func() {
 	Context("HNS network doesn't exist", func() {
 
 		BeforeEach(func() {
-			nets, err := driver.ListHNSNetworks()
+			nets, err := ListHNSNetworks()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(nets)).To(Equal(originalNumNetworks))
 		})
 
 		AfterEach(func() {
-			nets, err := driver.ListHNSNetworks()
+			nets, err := ListHNSNetworks()
 			Expect(err).ToNot(HaveOccurred())
 			for _, n := range nets {
 				if strings.Contains(n.Name, "nat") {
 					continue
 				}
-				err = driver.DeleteHNSNetwork(n.Id)
+				err = DeleteHNSNetwork(n.Id)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
 
 		Specify("getting single HNS network returns error", func() {
-			net, err := driver.GetHNSNetwork("1234abcd")
+			net, err := GetHNSNetwork("1234abcd")
 			Expect(err).To(HaveOccurred())
 			Expect(net).To(BeNil())
 		})
 
 		Specify("getting single HNS network by name returns error", func() {
-			net, err := driver.GetHNSNetworkByName("asdf")
+			net, err := GetHNSNetworkByName("asdf")
 			Expect(err).To(HaveOccurred())
 			Expect(net).To(BeNil())
 		})

--- a/main.go
+++ b/main.go
@@ -12,12 +12,17 @@ func main() {
 	var gateway = flag.String("gateway", "172.117.0.1", "default gateway IP for HNS")
 	var adapter = flag.String("adapter", "Ethernet0",
 		"net adapter for HNS switch, must be physical")
+	var controllerIP = flag.String("controllerIP", "127.0.0.1",
+		"IP address of Contrail Controller API")
+	var controllerPort = flag.Int("controllerPort", 8082,
+		"port of Contrail Controller API")
 	flag.Parse()
 
 	var d *driver.ContrailDriver
 	var err error
 
-	if d, err = driver.NewDriver(*subnet, *gateway, *adapter); err != nil {
+	if d, err = driver.NewDriver(*subnet, *gateway, *adapter, *controllerIP,
+		*controllerPort); err != nil {
 		logrus.Error(err)
 		return
 	}


### PR DESCRIPTION
Moved each component with tests to own package.

Tests that use HNS now perform a hard reset of HNS before/after tests.

Refactored common contrail client test code to be reusable in driver
test code.

Added controller API and port as command line args.