### PR TITLE
Test on actual controller

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -21,8 +21,8 @@ func NewController(ip string, port int) (*Controller, error) {
 	client := &Controller{}
 	client.ApiClient = contrail.NewClient(ip, port)
 
-	// TODO: use environment variables for keystone auth
-	keystone := contrail.NewKeystoneClient("http://10.7.0.54:5000/v2.0", "agatka", "admin",
+	// TODO: use environment variables for keystone auth (JW-66)
+	keystone := contrail.NewKeystoneClient("http://10.7.0.54:5000/v2.0", "admin", "admin",
 		"secret123", "")
 	err := keystone.Authenticate()
 	if err != nil {
@@ -64,14 +64,13 @@ func (c *Controller) GetDefaultGatewayIp(net *types.VirtualNetwork) (string, err
 }
 
 func (c *Controller) GetOrCreateInstance(tenantName, containerId string) (*types.VirtualMachine, error) {
-	name := fmt.Sprintf("%s:%s:%s", common.DomainName, tenantName, containerId)
-	instance, err := types.VirtualMachineByName(c.ApiClient, name)
+	instance, err := types.VirtualMachineByName(c.ApiClient, containerId)
 	if err == nil && instance != nil {
 		return instance, nil
 	}
 
 	instance = new(types.VirtualMachine)
-	instance.SetFQName("project", []string{common.DomainName, tenantName, containerId})
+	instance.SetName(containerId)
 	err = c.ApiClient.Create(instance)
 	if err != nil {
 		return nil, err
@@ -81,16 +80,14 @@ func (c *Controller) GetOrCreateInstance(tenantName, containerId string) (*types
 
 func (c *Controller) GetOrCreateInterface(net *types.VirtualNetwork,
 	instance *types.VirtualMachine) (*types.VirtualMachineInterface, error) {
-	instanceFQName := instance.GetFQName()
-	namespace := instanceFQName[len(instanceFQName)-2]
-	name := fmt.Sprintf("%s:%s:%s", common.DomainName, namespace, instance.GetName())
-	iface, err := types.VirtualMachineInterfaceByName(c.ApiClient, name)
+	iface, err := types.VirtualMachineInterfaceByName(c.ApiClient, instance.GetName())
 	if err == nil && iface != nil {
 		return iface, nil
 	}
 
 	iface = new(types.VirtualMachineInterface)
-	iface.SetFQName("project", []string{common.DomainName, namespace, instance.GetName()})
+	instanceFQName := instance.GetFQName()
+	iface.SetFQName("", instanceFQName)
 	err = iface.AddVirtualMachine(instance)
 	if err != nil {
 		return nil, err
@@ -116,16 +113,13 @@ func (c *Controller) GetInterfaceMac(iface *types.VirtualMachineInterface) (stri
 
 func (c *Controller) GetOrCreateInstanceIp(net *types.VirtualNetwork,
 	iface *types.VirtualMachineInterface) (*types.InstanceIp, error) {
-	ifaceFQName := iface.GetFQName()
-	tenantName := ifaceFQName[len(ifaceFQName)-2]
-	name := fmt.Sprintf("%s_%s", tenantName, iface.GetName())
-	instIp, err := types.InstanceIpByName(c.ApiClient, name)
+	instIp, err := types.InstanceIpByName(c.ApiClient, iface.GetName())
 	if err == nil && instIp != nil {
 		return instIp, nil
 	}
 
 	instIp = &types.InstanceIp{}
-	instIp.SetName(name)
+	instIp.SetName(iface.GetName())
 	err = instIp.AddVirtualNetwork(net)
 	if err != nil {
 		return nil, err

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/Juniper/contrail-go-api/types"
@@ -8,6 +9,18 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var controllerAddr string
+var controllerPort int
+var useActualController bool
+
+func init() {
+	flag.StringVar(&controllerAddr, "controllerAddr",
+		"10.7.0.54", "Contrail controller addr")
+	flag.IntVar(&controllerPort, "controllerPort", 8082, "Contrail controller port")
+	flag.BoolVar(&useActualController, "useActualController", true,
+		"Whether to use mocked controller or actual.")
+}
 
 func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -31,7 +44,11 @@ var _ = Describe("Controller", func() {
 	var project *types.Project
 
 	BeforeEach(func() {
-		client, project = NewMockedClientAndProject(tenantName)
+		if useActualController {
+			client, project = NewClientAndProject(tenantName, controllerAddr, controllerPort)
+		} else {
+			client, project = NewMockedClientAndProject(tenantName)
+		}
 	})
 
 	Describe("getting Contrail network", func() {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -43,11 +43,24 @@ var _ = Describe("Controller", func() {
 	var client *Controller
 	var project *types.Project
 
+	BeforeSuite(func() {
+		if useActualController {
+			client, project = NewClientAndProject(tenantName, controllerAddr, controllerPort)
+			CleanupLingeringVM(client.ApiClient, containerID)
+		}
+	})
+
 	BeforeEach(func() {
 		if useActualController {
 			client, project = NewClientAndProject(tenantName, controllerAddr, controllerPort)
 		} else {
 			client, project = NewMockedClientAndProject(tenantName)
+		}
+	})
+
+	AfterEach(func() {
+		if useActualController {
+			CleanupLingeringVM(client.ApiClient, containerID)
 		}
 	})
 
@@ -61,7 +74,7 @@ var _ = Describe("Controller", func() {
 			It("returns it", func() {
 				net, err := client.GetNetwork(tenantName, networkName)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(net).To(BeEquivalentTo(testNetwork))
+				Expect(net.GetUuid()).To(Equal(testNetwork.GetUuid()))
 			})
 		})
 		Context("when network doesn't exist in Contrail", func() {
@@ -95,8 +108,14 @@ var _ = Describe("Controller", func() {
 			})
 			It("returns error", func() {
 				gwAddr, err := client.GetDefaultGatewayIp(testNetwork)
-				Expect(err).To(HaveOccurred())
-				Expect(gwAddr).To(Equal(""))
+				if useActualController {
+					Expect(gwAddr).ToNot(Equal(""))
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					// mocked controller lacks some logic here
+					Expect(gwAddr).To(Equal(""))
+					Expect(err).To(HaveOccurred())
+				}
 			})
 		})
 		Context("network doesn't have subnets", func() {
@@ -113,7 +132,7 @@ var _ = Describe("Controller", func() {
 	})
 
 	Describe("getting Contrail instance", func() {
-		Context("when instance already exists in Cotnrail", func() {
+		Context("when instance already exists in Contrail", func() {
 			var testInstance *types.VirtualMachine
 			BeforeEach(func() {
 				testInstance = CreateMockedInstance(client.ApiClient, tenantName, containerID)
@@ -122,7 +141,7 @@ var _ = Describe("Controller", func() {
 				instance, err := client.GetOrCreateInstance(tenantName, containerID)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(instance).ToNot(BeNil())
-				Expect(instance).To(BeEquivalentTo(testInstance))
+				Expect(instance.GetUuid()).To(Equal(testInstance.GetUuid()))
 			})
 		})
 		Context("when instance doesn't exist in Contrail", func() {
@@ -134,7 +153,7 @@ var _ = Describe("Controller", func() {
 				existingInst, err := types.VirtualMachineByUuid(client.ApiClient,
 					instance.GetUuid())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(existingInst).To(BeEquivalentTo(instance))
+				Expect(existingInst.GetUuid()).To(Equal(instance.GetUuid()))
 			})
 		})
 	})
@@ -157,7 +176,7 @@ var _ = Describe("Controller", func() {
 				iface, err := client.GetOrCreateInterface(testNetwork, testInstance)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(iface).ToNot(BeNil())
-				Expect(iface).To(BeEquivalentTo(testInterface))
+				Expect(iface.GetUuid()).To(Equal(testInterface.GetUuid()))
 			})
 		})
 		Context("when vif doesn't exist in Contrail", func() {
@@ -169,7 +188,7 @@ var _ = Describe("Controller", func() {
 				existingIface, err := types.VirtualMachineInterfaceByUuid(client.ApiClient,
 					iface.GetUuid())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(existingIface).To(BeEquivalentTo(iface))
+				Expect(existingIface.GetUuid()).To(Equal(iface.GetUuid()))
 			})
 		})
 	})
@@ -225,9 +244,9 @@ var _ = Describe("Controller", func() {
 				instanceIP, err := client.GetOrCreateInstanceIp(testNetwork, testInterface)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(instanceIP).ToNot(BeNil())
-				Expect(instanceIP).To(BeEquivalentTo(testInstanceIP))
+				Expect(instanceIP.GetUuid()).To(Equal(testInstanceIP.GetUuid()))
 
-				// TODO: check if got an IP address
+				// TODO: check if got an IP address (instance_ip_address)
 
 			})
 		})
@@ -239,9 +258,9 @@ var _ = Describe("Controller", func() {
 
 				existingIP, err := types.InstanceIpByUuid(client.ApiClient, instanceIP.GetUuid())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(existingIP).To(BeEquivalentTo(instanceIP))
+				Expect(existingIP.GetUuid()).To(Equal(instanceIP.GetUuid()))
 
-				// TODO: check if got an IP address
+				// TODO: check if got an IP address (instance_ip_address)
 			})
 		})
 	})

--- a/controller/controller_test_helpers.go
+++ b/controller/controller_test_helpers.go
@@ -24,6 +24,17 @@ func NewMockedClientAndProject(tenant string) (*Controller, *types.Project) {
 	return c, project
 }
 
+func NewClientAndProject(tenant, controllerAddr string, controllerPort int) (*Controller,
+	*types.Project) {
+	c, err := NewController(controllerAddr, controllerPort)
+	Expect(err).ToNot(HaveOccurred())
+
+	project, err := c.ApiClient.FindByName("project", fmt.Sprintf("%s:%s", common.DomainName,
+		tenant))
+	Expect(err).ToNot(HaveOccurred())
+	return c, project.(*types.Project)
+}
+
 func CreateMockedNetworkWithSubnet(c contrail.ApiClient, netName, subnetCIDR string,
 	project *types.Project) *types.VirtualNetwork {
 	netUUID, err := config.CreateNetworkWithSubnet(c, project.GetUuid(), netName, subnetCIDR)

--- a/controller/controller_test_helpers.go
+++ b/controller/controller_test_helpers.go
@@ -3,10 +3,15 @@ package controller
 import (
 	"fmt"
 
+	"strings"
+
+	"regexp"
+
 	contrail "github.com/Juniper/contrail-go-api"
 	"github.com/Juniper/contrail-go-api/config"
 	"github.com/Juniper/contrail-go-api/mocks"
 	"github.com/Juniper/contrail-go-api/types"
+	log "github.com/Sirupsen/logrus"
 	"github.com/codilime/contrail-windows-docker/common"
 	. "github.com/onsi/gomega"
 )
@@ -29,10 +34,14 @@ func NewClientAndProject(tenant, controllerAddr string, controllerPort int) (*Co
 	c, err := NewController(controllerAddr, controllerPort)
 	Expect(err).ToNot(HaveOccurred())
 
-	project, err := c.ApiClient.FindByName("project", fmt.Sprintf("%s:%s", common.DomainName,
-		tenant))
+	ForceDeleteProject(c.ApiClient, tenant)
+
+	project := new(types.Project)
+	project.SetFQName("domain", []string{common.DomainName, tenant})
 	Expect(err).ToNot(HaveOccurred())
-	return c, project.(*types.Project)
+	err = c.ApiClient.Create(project)
+	Expect(err).ToNot(HaveOccurred())
+	return c, project
 }
 
 func CreateMockedNetworkWithSubnet(c contrail.ApiClient, netName, subnetCIDR string,
@@ -80,7 +89,7 @@ func AddSubnetWithDefaultGateway(c contrail.ApiClient, subnetPrefix, defaultGW s
 func CreateMockedInstance(c contrail.ApiClient, tenantName,
 	containerID string) *types.VirtualMachine {
 	testInstance := new(types.VirtualMachine)
-	testInstance.SetFQName("project", []string{common.DomainName, tenantName, containerID})
+	testInstance.SetName(containerID)
 	err := c.Create(testInstance)
 	Expect(err).ToNot(HaveOccurred())
 	return testInstance
@@ -90,8 +99,7 @@ func CreateMockedInterface(c contrail.ApiClient, instance *types.VirtualMachine,
 	net *types.VirtualNetwork) *types.VirtualMachineInterface {
 	iface := new(types.VirtualMachineInterface)
 	instanceFQName := instance.GetFQName()
-	namespace := instanceFQName[len(instanceFQName)-2]
-	iface.SetFQName("project", []string{common.DomainName, namespace, instance.GetName()})
+	iface.SetFQName("", instanceFQName)
 	err := iface.AddVirtualMachine(instance)
 	Expect(err).ToNot(HaveOccurred())
 	err = iface.AddVirtualNetwork(net)
@@ -113,10 +121,8 @@ func AddMacToInterface(c contrail.ApiClient, ifaceMac string,
 func CreateMockedInstanceIP(c contrail.ApiClient, tenantName string,
 	iface *types.VirtualMachineInterface,
 	net *types.VirtualNetwork) *types.InstanceIp {
-	name := fmt.Sprintf("%s_%s", tenantName, iface.GetName())
-
 	instIP := &types.InstanceIp{}
-	instIP.SetName(name)
+	instIP.SetName(iface.GetName())
 	err := instIP.AddVirtualNetwork(net)
 	Expect(err).ToNot(HaveOccurred())
 	err = instIP.AddVirtualMachineInterface(iface)
@@ -127,4 +133,56 @@ func CreateMockedInstanceIP(c contrail.ApiClient, tenantName string,
 	allocatedIP, err := types.InstanceIpByUuid(c, instIP.GetUuid())
 	Expect(err).ToNot(HaveOccurred())
 	return allocatedIP
+}
+
+func ForceDeleteProject(c contrail.ApiClient, tenant string) {
+	projToDelete, _ := c.FindByName("project", fmt.Sprintf("%s:%s", common.DomainName,
+		tenant))
+	if projToDelete != nil {
+		deleteElement(c, projToDelete)
+	}
+}
+
+func CleanupLingeringVM(c contrail.ApiClient, containerID string) {
+	instance, err := types.VirtualMachineByName(c, containerID)
+	if err == nil {
+		log.Debugln("Cleaning up lingering test vm", instance.GetUuid())
+		deleteElement(c, instance)
+	}
+}
+
+func deleteElement(c contrail.ApiClient, parent contrail.IObject) {
+	log.Debugln("Deleting", parent.GetType(), parent.GetUuid())
+	err := c.Delete(parent)
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Resource") {
+			return
+		} else if strings.Contains(err.Error(), "409 Conflict") {
+			msg := err.Error()
+			// example error message when object has children:
+			// `409 Conflict: Delete when children still present:
+			// ['http://10.7.0.54:8082/virtual-network/23e300f4-ab1a-4d97-a1d9-9ed69b601e17']`
+
+			// This regex finds all strings like:
+			// `virtual-network/23e300f4-ab1a-4d97-a1d9-9ed69b601e17`
+			var re *regexp.Regexp
+			re, err = regexp.Compile(
+				"([a-z-]*\\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")
+			Expect(err).ToNot(HaveOccurred())
+			found := re.FindAll([]byte(msg), -1)
+
+			for _, f := range found {
+				split := strings.Split(string(f), "/")
+				typename := split[0]
+				UUID := split[1]
+				var child contrail.IObject
+				child, err = c.FindByUuid(typename, UUID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(child).ToNot(BeNil())
+				deleteElement(c, child)
+			}
+		}
+		err = c.Delete(parent)
+		Expect(err).ToNot(HaveOccurred())
+	}
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/codilime/contrail-windows-docker/common"
 	"github.com/codilime/contrail-windows-docker/controller"
 	"github.com/codilime/contrail-windows-docker/hns"
@@ -20,7 +20,7 @@ type ContrailDriver struct {
 	HnsID      string
 }
 
-func NewDriver(subnet, gateway, adapter, controllerIP string, controllerPort int) (*ContrailDriver,
+func NewDriver(subnet, gateway, adapter string, c *controller.Controller) (*ContrailDriver,
 	error) {
 
 	subnets := []hcsshim.Subnet{
@@ -43,7 +43,7 @@ func NewDriver(subnet, gateway, adapter, controllerIP string, controllerPort int
 	}
 
 	d := &ContrailDriver{
-		controller: controller.NewController(controllerIP, controllerPort),
+		controller: c,
 		HnsID:      hnsID,
 	}
 	return d, nil
@@ -70,25 +70,25 @@ func (d *ContrailDriver) Teardown() error {
 }
 
 func (d *ContrailDriver) GetCapabilities() (*network.CapabilitiesResponse, error) {
-	logrus.Debugln("=== GetCapabilities")
+	log.Debugln("=== GetCapabilities")
 	r := &network.CapabilitiesResponse{}
 	r.Scope = network.LocalScope
 	return r, nil
 }
 
 func (d *ContrailDriver) CreateNetwork(req *network.CreateNetworkRequest) error {
-	logrus.Debugln("=== CreateNetwork")
-	logrus.Debugln("network.NetworkID =", req.NetworkID)
-	logrus.Debugln(req)
-	logrus.Debugln("IPv4:")
+	log.Debugln("=== CreateNetwork")
+	log.Debugln("network.NetworkID =", req.NetworkID)
+	log.Debugln(req)
+	log.Debugln("IPv4:")
 	for _, n := range req.IPv4Data {
-		logrus.Debugln(n)
+		log.Debugln(n)
 	}
-	logrus.Debugln("IPv6:")
+	log.Debugln("IPv6:")
 	for _, n := range req.IPv6Data {
-		logrus.Debugln(n)
+		log.Debugln(n)
 	}
-	logrus.Debugln("options:")
+	log.Debugln("options:")
 	for k, v := range req.Options {
 		fmt.Printf("%v: %v\n", k, v)
 	}
@@ -97,29 +97,29 @@ func (d *ContrailDriver) CreateNetwork(req *network.CreateNetworkRequest) error 
 }
 
 func (d *ContrailDriver) AllocateNetwork(req *network.AllocateNetworkRequest) (*network.AllocateNetworkResponse, error) {
-	logrus.Debugln("=== AllocateNetwork")
-	logrus.Debugln(req)
+	log.Debugln("=== AllocateNetwork")
+	log.Debugln(req)
 	r := &network.AllocateNetworkResponse{}
 	return r, nil
 }
 
 func (d *ContrailDriver) DeleteNetwork(req *network.DeleteNetworkRequest) error {
-	logrus.Debugln("=== DeleteNetwork")
-	logrus.Debugln(req)
+	log.Debugln("=== DeleteNetwork")
+	log.Debugln(req)
 	return nil
 }
 
 func (d *ContrailDriver) FreeNetwork(req *network.FreeNetworkRequest) error {
-	logrus.Debugln("=== FreeNetwork")
-	logrus.Debugln(req)
+	log.Debugln("=== FreeNetwork")
+	log.Debugln(req)
 	return nil
 }
 
 func (d *ContrailDriver) CreateEndpoint(req *network.CreateEndpointRequest) (*network.CreateEndpointResponse, error) {
-	logrus.Debugln("=== CreateEndpoint")
-	logrus.Debugln(req)
-	logrus.Debugln(req.Interface)
-	logrus.Debugln("options:")
+	log.Debugln("=== CreateEndpoint")
+	log.Debugln(req)
+	log.Debugln(req.Interface)
+	log.Debugln("options:")
 	for k, v := range req.Options {
 		fmt.Printf("%v: %v\n", k, v)
 	}
@@ -128,22 +128,22 @@ func (d *ContrailDriver) CreateEndpoint(req *network.CreateEndpointRequest) (*ne
 }
 
 func (d *ContrailDriver) DeleteEndpoint(req *network.DeleteEndpointRequest) error {
-	logrus.Debugln("=== DeleteEndpoint")
-	logrus.Debugln(req)
+	log.Debugln("=== DeleteEndpoint")
+	log.Debugln(req)
 	return nil
 }
 
 func (d *ContrailDriver) EndpointInfo(req *network.InfoRequest) (*network.InfoResponse, error) {
-	logrus.Debugln("=== EndpointInfo")
-	logrus.Debugln(req)
+	log.Debugln("=== EndpointInfo")
+	log.Debugln(req)
 	r := &network.InfoResponse{}
 	return r, nil
 }
 
 func (d *ContrailDriver) Join(req *network.JoinRequest) (*network.JoinResponse, error) {
-	logrus.Debugln("=== Join")
-	logrus.Debugln(req)
-	logrus.Debugln("options:")
+	log.Debugln("=== Join")
+	log.Debugln(req)
+	log.Debugln("options:")
 	for k, v := range req.Options {
 		fmt.Printf("%v: %v\n", k, v)
 	}
@@ -152,31 +152,31 @@ func (d *ContrailDriver) Join(req *network.JoinRequest) (*network.JoinResponse, 
 }
 
 func (d *ContrailDriver) Leave(req *network.LeaveRequest) error {
-	logrus.Debugln("=== Leave")
-	logrus.Debugln(req)
+	log.Debugln("=== Leave")
+	log.Debugln(req)
 	return nil
 }
 
 func (d *ContrailDriver) DiscoverNew(req *network.DiscoveryNotification) error {
-	logrus.Debugln("=== DiscoverNew")
-	logrus.Debugln(req)
+	log.Debugln("=== DiscoverNew")
+	log.Debugln(req)
 	return nil
 }
 
 func (d *ContrailDriver) DiscoverDelete(req *network.DiscoveryNotification) error {
-	logrus.Debugln("=== DiscoverDelete")
-	logrus.Debugln(req)
+	log.Debugln("=== DiscoverDelete")
+	log.Debugln(req)
 	return nil
 }
 
 func (d *ContrailDriver) ProgramExternalConnectivity(req *network.ProgramExternalConnectivityRequest) error {
-	logrus.Debugln("=== ProgramExternalConnectivity")
-	logrus.Debugln(req)
+	log.Debugln("=== ProgramExternalConnectivity")
+	log.Debugln(req)
 	return nil
 }
 
 func (d *ContrailDriver) RevokeExternalConnectivity(req *network.RevokeExternalConnectivityRequest) error {
-	logrus.Debugln("=== RevokeExternalConnectivity")
-	logrus.Debugln(req)
+	log.Debugln("=== RevokeExternalConnectivity")
+	log.Debugln(req)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/codilime/contrail-windows-docker/controller"
 	"github.com/codilime/contrail-windows-docker/driver"
 )
 
@@ -19,10 +20,15 @@ func main() {
 	flag.Parse()
 
 	var d *driver.ContrailDriver
+	var c *controller.Controller
 	var err error
 
-	if d, err = driver.NewDriver(*subnet, *gateway, *adapter, *controllerIP,
-		*controllerPort); err != nil {
+	if c, err = controller.NewController(*controllerIP, *controllerPort); err != nil {
+		logrus.Error(err)
+		return
+	}
+
+	if d, err = driver.NewDriver(*subnet, *gateway, *adapter, c); err != nil {
 		logrus.Error(err)
 		return
 	}


### PR DESCRIPTION
Uses actual Contrail instance for testing. Added command line options to tests to specify if one wants to use the mocked version, and the address of Contrail instance. Had to change parent object of virtual-machine and virtual-machine-interface to work with Contrail 3+.