### PR TITLE
JW-61 Added net adapter selection option to tests.

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -14,11 +14,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var netAdapter string
 var controllerAddr string
 var controllerPort int
 var useActualController bool
 
 func init() {
+	flag.StringVar(&netAdapter, "netAdapter", "Ethernet0",
+		"Network adapter to connect HNS switch to")
 	flag.StringVar(&controllerAddr, "controllerAddr",
 		"10.7.0.54", "Contrail controller addr")
 	flag.IntVar(&controllerPort, "controllerPort", 8082, "Contrail controller port")
@@ -239,7 +242,7 @@ func startDriver() *ContrailDriver {
 	} else {
 		c, _ = controller.NewMockedClientAndProject("some_tenant_name")
 	}
-	d, err := NewDriver("172.100.0.0/16", "172.100.0.1", "Ethernet0", c)
+	d, err := NewDriver("172.100.0.0/16", "172.100.0.1", netAdapter, c)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(d.HnsID).ToNot(Equal(""))
 	return d

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -1,6 +1,7 @@
 package hns
 
 import (
+	"flag"
 	"strings"
 	"testing"
 
@@ -9,6 +10,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var netAdapter string
+
+func init() {
+	flag.StringVar(&netAdapter, "netAdapter", "Ethernet0",
+		"Network adapter to connect HNS switch to")
+}
 
 func TestHNS(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -36,15 +44,6 @@ var _ = Describe("HNS wrapper", func() {
 	})
 
 	Context("HNS network exists", func() {
-		/*
-			There's an issue with HNS where deleting a network and then creating one
-			immediately after doesn't work (https://github.com/Microsoft/hcsshim/issues/95).
-			A way to fix this is to have a long timeout before creating a network (like 20
-			seconds), which is way too long for test suite such as this one.
-			Ideally, we would like to call Create/Delete a test network for each of the
-			following test cases, but it would take too long. So a single test network will
-			be shared for all of them.
-		*/
 
 		testNetName := "TestNetwork"
 		testHnsNetID := ""
@@ -59,7 +58,7 @@ var _ = Describe("HNS wrapper", func() {
 			Name:               testNetName,
 			Type:               "transparent",
 			Subnets:            subnets,
-			NetworkAdapterName: "Ethernet0",
+			NetworkAdapterName: netAdapter,
 		}
 
 		BeforeEach(func() {


### PR DESCRIPTION
Let's user specify a network adapter that HNS switch should be connected to during testing.