### PR TITLE
JW-43 (docker api) Handle create requests

### DIFF
--- a/ci/clone_and_test.ps1
+++ b/ci/clone_and_test.ps1
@@ -20,8 +20,9 @@ cd C:\go_workspace\bin
 go build github.com/codilime/contrail-windows-docker
 
 echo "Downloading test framework"
-go get github.com/onsi/ginkgo/ginkgo
-go get github.com/onsi/gomega
+go get -u github.com/onsi/ginkgo/ginkgo
+go get -u github.com/onsi/gomega
+go get -u github.com/onsi/ginkgo/extensions/table
 
 echo "Running tests"
 cd C:\go_workspace\src\github.com\codilime\contrail-windows-docker

--- a/common/config.go
+++ b/common/config.go
@@ -1,5 +1,10 @@
 package common
 
+import (
+	"os"
+	"path/filepath"
+)
+
 const (
 	// DomainName specifies domain name in Contrail
 	DomainName = "default-domain"
@@ -7,6 +12,16 @@ const (
 	// DriverName is name of the driver that is to be specified during docker network creation
 	DriverName = "Contrail"
 
-	// HNSNetworkName is a constant name for HNS network
-	NetworkHNSname = "ContrailHNSNet"
+	// HNSNetworkPrefix is a prefix given too all HNS network names managed by the driver
+	HNSNetworkPrefix = "Contrail"
 )
+
+// PluginSpecDir returns path to directory where docker daemon looks for plugin spec files.
+func PluginSpecDir() string {
+	return ([]string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")})[0]
+}
+
+// PluginSpecFilePath returns path to plugin spec file.
+func PluginSpecFilePath() string {
+	return filepath.Join(PluginSpecDir(), DriverName+".spec")
+}

--- a/common/config.go
+++ b/common/config.go
@@ -18,7 +18,7 @@ const (
 
 // PluginSpecDir returns path to directory where docker daemon looks for plugin spec files.
 func PluginSpecDir() string {
-	return ([]string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")})[0]
+	return filepath.Join(os.Getenv("programdata"), "docker", "plugins")
 }
 
 // PluginSpecFilePath returns path to plugin spec file.

--- a/common/misc.go
+++ b/common/misc.go
@@ -3,7 +3,9 @@ package common
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -18,15 +20,21 @@ func HardResetHNS() error {
 	log.Debugln("Removing container networks")
 	if err := exec.Command("powershell", "Get-ContainerNetwork", "|",
 		"Remove-ContainerNetwork", "-Force").Run(); err != nil {
-		log.Debugln("Could not remove container network.")
+		log.Debugln("Could not remove nat network.")
 	}
 	log.Debugln("Stopping HNS")
 	if err := exec.Command("powershell", "Stop-Service", "hns").Run(); err != nil {
 		log.Debugln("HNS is already stopped.")
 	}
 	log.Debugln("Removing HNS program data")
-	if err := exec.Command("powershell", "Remove-Item",
-		"C:\\ProgramData\\Microsoft\\Windows\\HNS\\HNS.data").Run(); err != nil {
+
+	programData := os.Getenv("programdata")
+	if programData == "" {
+		log.Errorln("Invalid program data env variable")
+		return errors.New("Invalid program data env variable")
+	}
+	hnsDataDir := filepath.Join(programData, "Microsoft", "Windows", "HNS", "HNS.data")
+	if err := exec.Command("powershell", "Remove-Item", hnsDataDir).Run(); err != nil {
 		return errors.New(fmt.Sprintf("Error during removing HNS program data: %s", err))
 	}
 	log.Debugln("Starting HNS")

--- a/common/misc.go
+++ b/common/misc.go
@@ -1,15 +1,23 @@
 package common
 
 import (
+	"errors"
+	"fmt"
 	"os/exec"
 
 	log "github.com/Sirupsen/logrus"
 )
 
 func HardResetHNS() error {
+	log.Infoln("Resetting HNS")
+	log.Debugln("Removing NAT")
+	if err := exec.Command("powershell", "Get-NetNat", "|",
+		"Remove-NetNat").Run(); err != nil {
+		log.Debugln("Could not remove container network.")
+	}
 	log.Debugln("Removing container networks")
 	if err := exec.Command("powershell", "Get-ContainerNetwork", "|",
-		"Remove-ContainerNetwork").Run(); err != nil {
+		"Remove-ContainerNetwork", "-Force").Run(); err != nil {
 		log.Debugln("Could not remove container network.")
 	}
 	log.Debugln("Stopping HNS")
@@ -19,10 +27,18 @@ func HardResetHNS() error {
 	log.Debugln("Removing HNS program data")
 	if err := exec.Command("powershell", "Remove-Item",
 		"C:\\ProgramData\\Microsoft\\Windows\\HNS\\HNS.data").Run(); err != nil {
-		return err
+		return errors.New(fmt.Sprintf("Error during removing HNS program data: %s", err))
 	}
 	log.Debugln("Starting HNS")
 	if err := exec.Command("powershell", "Start-Service", "hns").Run(); err != nil {
+		return errors.New(fmt.Sprintf("Error when starting HNS: %s", err))
+	}
+	return nil
+}
+
+func RestartDocker() error {
+	log.Infoln("Restarting docker")
+	if err := exec.Command("powershell", "Restart-Service", "docker").Run(); err != nil {
 		return err
 	}
 	return nil

--- a/common/misc.go
+++ b/common/misc.go
@@ -15,12 +15,12 @@ func HardResetHNS() error {
 	log.Debugln("Removing NAT")
 	if err := exec.Command("powershell", "Get-NetNat", "|",
 		"Remove-NetNat").Run(); err != nil {
-		log.Debugln("Could not remove container network.")
+		log.Debugln("Could not remove nat network.")
 	}
 	log.Debugln("Removing container networks")
 	if err := exec.Command("powershell", "Get-ContainerNetwork", "|",
 		"Remove-ContainerNetwork", "-Force").Run(); err != nil {
-		log.Debugln("Could not remove nat network.")
+		log.Debugln("Could not remove container network.")
 	}
 	log.Debugln("Stopping HNS")
 	if err := exec.Command("powershell", "Stop-Service", "hns").Run(); err != nil {
@@ -30,7 +30,6 @@ func HardResetHNS() error {
 
 	programData := os.Getenv("programdata")
 	if programData == "" {
-		log.Errorln("Invalid program data env variable")
 		return errors.New("Invalid program data env variable")
 	}
 	hnsDataDir := filepath.Join(programData, "Microsoft", "Windows", "HNS", "HNS.data")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -44,23 +44,31 @@ func (c *Controller) GetNetwork(tenantName, networkName string) (*types.VirtualN
 	return net, nil
 }
 
-func (c *Controller) GetDefaultGatewayIp(net *types.VirtualNetwork) (string, error) {
+func (c *Controller) GetIpamSubnet(net *types.VirtualNetwork) (*types.IpamSubnetType, error) {
 	ipamReferences, err := net.GetNetworkIpamRefs()
 	if err != nil {
 		log.Errorf("Failed to get ipam references: %v", err)
-		return "", err
+		return nil, err
 	}
 	if len(ipamReferences) == 0 {
 		log.Errorf("Ipam references list is empty")
-		return "", errors.New("Ipam references list is empty")
+		return nil, errors.New("Ipam references list is empty")
 	}
 	attribute := ipamReferences[0].Attr
 	ipamSubnets := attribute.(types.VnSubnetsType).IpamSubnets
 	if len(ipamSubnets) == 0 {
 		log.Errorf("Ipam subnets list is empty")
-		return "", errors.New("Ipam subnets list is empty")
+		return nil, errors.New("Ipam subnets list is empty")
 	}
-	gw := ipamSubnets[0].DefaultGateway
+	return &ipamSubnets[0], nil
+}
+
+func (c *Controller) GetDefaultGatewayIp(net *types.VirtualNetwork) (string, error) {
+	subnet, err := c.GetIpamSubnet(net)
+	if err != nil {
+		return "", err
+	}
+	gw := subnet.DefaultGateway
 	if gw == "" {
 		log.Errorf("Default GW is empty")
 		return "", errors.New("Default GW is empty")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -51,14 +51,16 @@ func (c *Controller) GetIpamSubnet(net *types.VirtualNetwork) (*types.IpamSubnet
 		return nil, err
 	}
 	if len(ipamReferences) == 0 {
-		log.Errorf("Ipam references list is empty")
-		return nil, errors.New("Ipam references list is empty")
+		err = errors.New("Ipam references list is empty")
+		log.Error(err)
+		return nil, err
 	}
 	attribute := ipamReferences[0].Attr
 	ipamSubnets := attribute.(types.VnSubnetsType).IpamSubnets
 	if len(ipamSubnets) == 0 {
-		log.Errorf("Ipam subnets list is empty")
-		return nil, errors.New("Ipam subnets list is empty")
+		err = errors.New("Ipam subnets list is empty")
+		log.Error(err)
+		return nil, err
 	}
 	return &ipamSubnets[0], nil
 }
@@ -70,8 +72,9 @@ func (c *Controller) GetDefaultGatewayIp(net *types.VirtualNetwork) (string, err
 	}
 	gw := subnet.DefaultGateway
 	if gw == "" {
-		log.Errorf("Default GW is empty")
-		return "", errors.New("Default GW is empty")
+		err = errors.New("Default GW is empty")
+		log.Error(err)
+		return "", err
 	}
 	return gw, nil
 }
@@ -135,8 +138,9 @@ func (c *Controller) GetOrCreateInterface(net *types.VirtualNetwork,
 func (c *Controller) GetInterfaceMac(iface *types.VirtualMachineInterface) (string, error) {
 	macs := iface.GetVirtualMachineInterfaceMacAddresses()
 	if len(macs.MacAddress) == 0 {
-		log.Errorf("Retreived empty MAC list")
-		return "", errors.New("Empty MAC list")
+		err := errors.New("Empty MAC list")
+		log.Error(err)
+		return "", err
 	}
 	return macs.MacAddress[0], nil
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Controller", func() {
 		})
 	})
 
-	Describe("getting Contrail default gateway IP", func() {
+	Describe("getting Contrail subnet info", func() {
 		Context("network has subnet with default gateway", func() {
 			var testNetwork *types.VirtualNetwork
 			BeforeEach(func() {
@@ -98,10 +98,16 @@ var _ = Describe("Controller", func() {
 				AddSubnetWithDefaultGateway(client.ApiClient, subnetPrefix, defaultGW,
 					subnetMask, testNetwork)
 			})
-			It("returns gateway IP", func() {
+			Specify("getting default gw IP works", func() {
 				gwAddr, err := client.GetDefaultGatewayIp(testNetwork)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(gwAddr).ToNot(Equal(""))
+			})
+			Specify("getting subnet prefix and prefix len works", func() {
+				ipam, err := client.GetIpamSubnet(testNetwork)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ipam.Subnet.IpPrefix).To(Equal(subnetPrefix))
+				Expect(ipam.Subnet.IpPrefixLen).To(Equal(subnetMask))
 			})
 		})
 		Context("network has subnet without default gateway", func() {
@@ -110,7 +116,7 @@ var _ = Describe("Controller", func() {
 				testNetwork = CreateMockedNetworkWithSubnet(client.ApiClient, networkName,
 					subnetCIDR, project)
 			})
-			It("returns error", func() {
+			Specify("getting default gw IP returns error", func() {
 				gwAddr, err := client.GetDefaultGatewayIp(testNetwork)
 				if useActualController {
 					Expect(gwAddr).ToNot(Equal(""))
@@ -121,16 +127,27 @@ var _ = Describe("Controller", func() {
 					Expect(err).To(HaveOccurred())
 				}
 			})
+			Specify("getting subnet prefix and prefix len works", func() {
+				ipam, err := client.GetIpamSubnet(testNetwork)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ipam.Subnet.IpPrefix).To(Equal(subnetPrefix))
+				Expect(ipam.Subnet.IpPrefixLen).To(Equal(subnetMask))
+			})
 		})
 		Context("network doesn't have subnets", func() {
 			var testNetwork *types.VirtualNetwork
 			BeforeEach(func() {
 				testNetwork = CreateMockedNetwork(client.ApiClient, networkName, project)
 			})
-			It("returns error", func() {
+			Specify("getting default gw IP returns error", func() {
 				gwAddr, err := client.GetDefaultGatewayIp(testNetwork)
 				Expect(err).To(HaveOccurred())
 				Expect(gwAddr).To(Equal(""))
+			})
+			Specify("getting subnet prefix and prefix len returns error", func() {
+				ipam, err := client.GetIpamSubnet(testNetwork)
+				Expect(err).To(HaveOccurred())
+				Expect(ipam).To(BeNil())
 			})
 		})
 	})

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -179,7 +179,7 @@ func (d *ContrailDriver) DeleteNetwork(req *network.DeleteNetworkRequest) error 
 	if err != nil {
 		return err
 	}
-	d.hnsMgr.DeleteNetwork(tenant, netName)
+	err = d.hnsMgr.DeleteNetwork(tenant, netName)
 	if err != nil {
 		return err
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,69 +4,92 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"time"
 
+	"context"
+
+	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim"
 	log "github.com/Sirupsen/logrus"
 	"github.com/codilime/contrail-windows-docker/common"
 	"github.com/codilime/contrail-windows-docker/controller"
 	"github.com/codilime/contrail-windows-docker/hns"
+	"github.com/codilime/contrail-windows-docker/hnsManager"
+	dockerClient "github.com/docker/docker/client"
 	"github.com/docker/go-plugins-helpers/network"
-	"github.com/docker/go-plugins-helpers/sdk"
 )
 
 type ContrailDriver struct {
-	controller *controller.Controller
-	HnsID      string
+	controller     *controller.Controller
+	hnsMgr         *hnsManager.HNSManager
+	networkAdapter string
+	listener       net.Listener
 }
 
-func NewDriver(subnet, gateway, adapter string, c *controller.Controller) (*ContrailDriver,
-	error) {
-
-	subnets := []hcsshim.Subnet{
-		{
-			AddressPrefix:  subnet,
-			GatewayAddress: gateway,
-		},
-	}
-
-	configuration := &hcsshim.HNSNetwork{
-		Name:               common.NetworkHNSname,
-		Type:               "transparent",
-		Subnets:            subnets,
-		NetworkAdapterName: adapter,
-	}
-
-	hnsID, err := hns.CreateHNSNetwork(configuration)
-	if err != nil {
-		return nil, err
-	}
+func NewDriver(adapter string, c *controller.Controller) (*ContrailDriver, error) {
 
 	d := &ContrailDriver{
-		controller: c,
-		HnsID:      hnsID,
+		controller:     c,
+		hnsMgr:         &hnsManager.HNSManager{},
+		networkAdapter: adapter,
 	}
 	return d, nil
 }
 
-func (d *ContrailDriver) Serve() error {
-	h := network.NewHandler(d)
+func (d *ContrailDriver) StartServing() error {
 
-	config := sdk.WindowsPipeConfig{
-		// This will set permissions for Service, System, Adminstrator group and account to have full access
+	pipeConfig := winio.PipeConfig{
+		// This will set permissions for Service, System, Adminstrator group and account to
+		// have full access
 		SecurityDescriptor: "D:(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;FA;;;LA)(A;ID;FA;;;LS)",
-
-		InBufferSize:  4096,
-		OutBufferSize: 4096,
+		MessageMode:        true,
+		InputBufferSize:    4096,
+		OutputBufferSize:   4096,
 	}
 
-	h.ServeWindows("//./pipe/"+common.DriverName, common.DriverName, &config)
+	var err error
+	pipeAddr := "//./pipe/" + common.DriverName
+	if d.listener, err = winio.ListenPipe(pipeAddr, &pipeConfig); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(common.PluginSpecDir(), 0755); err != nil {
+		return err
+	}
+
+	url := "npipe://" + d.listener.Addr().String()
+	if err := ioutil.WriteFile(common.PluginSpecFilePath(), []byte(url), 0644); err != nil {
+		return err
+	}
+
+	h := network.NewHandler(d)
+	go h.Serve(d.listener)
+
+	// wait for listener goroutine to spin up. I don't see more elegant way to do this.
+	time.Sleep(time.Second * 1)
+
+	log.Infoln("Started serving on ", pipeAddr)
+
 	return nil
 }
 
-func (d *ContrailDriver) Teardown() error {
-	err := hns.DeleteHNSNetwork(d.HnsID)
-	return err
+func (d *ContrailDriver) StopServing() error {
+	_ = os.Remove(common.PluginSpecFilePath())
+
+	if err := d.listener.Close(); err != nil {
+		log.Errorln(err)
+		return err
+	}
+
+	log.Infoln("Stopped serving")
+
+	return nil
 }
 
 func (d *ContrailDriver) GetCapabilities() (*network.CapabilitiesResponse, error) {
@@ -93,37 +116,181 @@ func (d *ContrailDriver) CreateNetwork(req *network.CreateNetworkRequest) error 
 		fmt.Printf("%v: %v\n", k, v)
 	}
 
-	return nil
+	reqGenericOptionsMap, exists := req.Options["com.docker.network.generic"]
+	if !exists {
+		return errors.New("Generic options missing")
+	}
+
+	genericOptions, ok := reqGenericOptionsMap.(map[string]interface{})
+	if !ok {
+		return errors.New("Malformed generic options")
+	}
+
+	tenant, exists := genericOptions["tenant"]
+	if !exists {
+		return errors.New("Tenant not specified")
+	}
+
+	netName, exists := genericOptions["network"]
+	if !exists {
+		return errors.New("Network name not specified")
+	}
+
+	// Check if network is already created in Contrail.
+	contrailNetwork, err := d.controller.GetNetwork(tenant.(string), netName.(string))
+	if err != nil {
+		return err
+	}
+	if contrailNetwork == nil {
+		return errors.New("Retreived Contrail network is nil")
+	}
+
+	log.Infoln("Got Contrail network", contrailNetwork.GetDisplayName())
+
+	contrailIpam, err := d.controller.GetIpamSubnet(contrailNetwork)
+	if err != nil {
+		return err
+	}
+	subnet := contrailIpam.Subnet
+	subnetCIDR := fmt.Sprintf("%s/%v", subnet.IpPrefix, subnet.IpPrefixLen)
+
+	gw, err := d.controller.GetDefaultGatewayIp(contrailNetwork)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.hnsMgr.CreateNetwork(d.networkAdapter, tenant.(string), netName.(string),
+		subnetCIDR, gw)
+
+	return err
 }
 
 func (d *ContrailDriver) AllocateNetwork(req *network.AllocateNetworkRequest) (*network.AllocateNetworkResponse, error) {
 	log.Debugln("=== AllocateNetwork")
 	log.Debugln(req)
-	r := &network.AllocateNetworkResponse{}
-	return r, nil
+	return nil, errors.New("AllocateNetwork is not implemented")
 }
 
 func (d *ContrailDriver) DeleteNetwork(req *network.DeleteNetworkRequest) error {
 	log.Debugln("=== DeleteNetwork")
 	log.Debugln(req)
+
+	tenant, netName, err := d.tenantAndNetnameFromDockerNetwork(req.NetworkID)
+	if err != nil {
+		return err
+	}
+	d.hnsMgr.DeleteNetwork(tenant, netName)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 func (d *ContrailDriver) FreeNetwork(req *network.FreeNetworkRequest) error {
 	log.Debugln("=== FreeNetwork")
 	log.Debugln(req)
-	return nil
+	return errors.New("FreeNetwork is not implemented")
 }
 
 func (d *ContrailDriver) CreateEndpoint(req *network.CreateEndpointRequest) (*network.CreateEndpointResponse, error) {
 	log.Debugln("=== CreateEndpoint")
 	log.Debugln(req)
 	log.Debugln(req.Interface)
+	log.Debugln(req.EndpointID)
 	log.Debugln("options:")
 	for k, v := range req.Options {
 		fmt.Printf("%v: %v\n", k, v)
 	}
-	r := &network.CreateEndpointResponse{}
+
+	tenant, netName, err := d.tenantAndNetnameFromDockerNetwork(req.NetworkID)
+	if err != nil {
+		return nil, err
+	}
+
+	contrailNetwork, err := d.controller.GetNetwork(tenant, netName)
+	log.Infoln("Retreived Contrail network:", contrailNetwork.GetUuid())
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO JW-187.
+	// We need to retreive Container ID here and use it instead of EndpointID as
+	// argument to d.controller.GetOrCreateInstance().
+	// EndpointID is equiv to interface, but in Contrail, we have a "VirtualMachine" in
+	// data model.
+	// A single VM can be connected to two or more overlay networks, but when we use
+	// EndpointID, this won't work.
+	// We need something like:
+	// containerID := req.Options["vmname"]
+	containerID := req.EndpointID
+
+	contrailInstance, err := d.controller.GetOrCreateInstance(tenant, containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	contrailVif, err := d.controller.GetOrCreateInterface(contrailNetwork, contrailInstance)
+	if err != nil {
+		return nil, err
+	}
+
+	contrailIP, err := d.controller.GetOrCreateInstanceIp(contrailNetwork, contrailVif)
+	log.Infoln("Retreived instance IP:", contrailIP.GetInstanceIpAddress())
+	if err != nil {
+		return nil, err
+	}
+
+	contrailGateway, err := d.controller.GetDefaultGatewayIp(contrailNetwork)
+	log.Infoln("Retreived GW address:", contrailGateway)
+	if err != nil {
+		return nil, err
+	}
+
+	contrailMac, err := d.controller.GetInterfaceMac(contrailVif)
+	log.Infoln("Retreived MAC:", contrailMac)
+	if err != nil {
+		return nil, err
+	}
+	// contrail MACs are like 11:22:aa:bb:cc:dd
+	// HNS needs MACs like 11-22-AA-BB-CC-DD
+	formattedMac := strings.Replace(strings.ToUpper(contrailMac), ":", "-", -1)
+
+	hnsNet, err := d.hnsMgr.GetNetwork(tenant, netName)
+	if err != nil {
+		return nil, err
+	}
+
+	hnsEndpointConfig := &hcsshim.HNSEndpoint{
+		VirtualNetworkName: hnsNet.Name,
+		Name:               req.EndpointID,
+		IPAddress:          net.ParseIP(contrailIP.GetInstanceIpAddress()),
+		MacAddress:         formattedMac,
+		GatewayAddress:     contrailGateway,
+	}
+
+	// TODO: maybe store hnsEndpointID somehow? is there a reason to?
+	// Maybe it will become more clear when implementing the rest of the API.
+	_, err = hns.CreateHNSEndpoint(hnsEndpointConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO JW-12: talk to vRouter here
+
+	contrailIpam, err := d.controller.GetIpamSubnet(contrailNetwork)
+	if err != nil {
+		return nil, err
+	}
+
+	epAddressCIDR := fmt.Sprintf("%s/%v", contrailIP.GetInstanceIpAddress(),
+		contrailIpam.Subnet.IpPrefixLen)
+
+	r := &network.CreateEndpointResponse{
+		Interface: &network.EndpointInterface{
+			Address:    epAddressCIDR,
+			MacAddress: contrailMac,
+		},
+	}
 	return r, nil
 }
 
@@ -147,7 +314,28 @@ func (d *ContrailDriver) Join(req *network.JoinRequest) (*network.JoinResponse, 
 	for k, v := range req.Options {
 		fmt.Printf("%v: %v\n", k, v)
 	}
-	r := &network.JoinResponse{}
+
+	tenant, netName, err := d.tenantAndNetnameFromDockerNetwork(req.NetworkID)
+	if err != nil {
+		return nil, err
+	}
+
+	contrailNetwork, err := d.controller.GetNetwork(tenant, netName)
+	log.Infoln("Retreived Contrail network:", contrailNetwork.GetUuid())
+	if err != nil {
+		return nil, err
+	}
+
+	gw, err := d.controller.GetDefaultGatewayIp(contrailNetwork)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &network.JoinResponse{
+		DisableGatewayService: true,
+		Gateway:               gw,
+	}
+
 	return r, nil
 }
 
@@ -179,4 +367,28 @@ func (d *ContrailDriver) RevokeExternalConnectivity(req *network.RevokeExternalC
 	log.Debugln("=== RevokeExternalConnectivity")
 	log.Debugln(req)
 	return nil
+}
+
+func (d *ContrailDriver) tenantAndNetnameFromDockerNetwork(dockerNetID string) (string, string, error) {
+	docker, err := dockerClient.NewEnvClient()
+	if err != nil {
+		return "", "", err
+	}
+
+	dockerNetwork, err := docker.NetworkInspect(context.Background(), dockerNetID)
+	if err != nil {
+		return "", "", err
+	}
+
+	tenant, exists := dockerNetwork.Options["tenant"]
+	if !exists {
+		return "", "", errors.New("Retreived network has no Contrail tenant specified")
+	}
+
+	netName, exists := dockerNetwork.Options["network"]
+	if !exists {
+		return "", "", errors.New("Retreived network has no Contrail network name specfied")
+	}
+
+	return tenant, netName, nil
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -32,14 +32,14 @@ type ContrailDriver struct {
 	listener       net.Listener
 }
 
-func NewDriver(adapter string, c *controller.Controller) (*ContrailDriver, error) {
+func NewDriver(adapter string, c *controller.Controller) *ContrailDriver {
 
 	d := &ContrailDriver{
 		controller:     c,
 		hnsMgr:         &hnsManager.HNSManager{},
 		networkAdapter: adapter,
 	}
-	return d, nil
+	return d
 }
 
 func (d *ContrailDriver) StartServing() error {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -518,8 +518,7 @@ func startDriver() (*ContrailDriver, *controller.Controller, *types.Project) {
 	} else {
 		c, p = controller.NewMockedClientAndProject(tenantName)
 	}
-	d, err := NewDriver("Ethernet0", c)
-	Expect(err).ToNot(HaveOccurred())
+	d := NewDriver("Ethernet0", c)
 
 	return d, c, p
 }

--- a/hns/hns.go
+++ b/hns/hns.go
@@ -2,7 +2,6 @@ package hns
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/Microsoft/hcsshim"
 	log "github.com/Sirupsen/logrus"
@@ -66,7 +65,7 @@ func GetHNSNetworkByName(name string) (*hcsshim.HNSNetwork, error) {
 			return &n, nil
 		}
 	}
-	return nil, errors.New("HNS network not found by name")
+	return nil, nil
 }
 
 func CreateHNSEndpoint(configuration *hcsshim.HNSEndpoint) (string, error) {
@@ -102,4 +101,12 @@ func GetHNSEndpoint(endpointID string) (*hcsshim.HNSEndpoint, error) {
 		return nil, err
 	}
 	return endpoint, nil
+}
+
+func ListHNSEndpoints() ([]hcsshim.HNSEndpoint, error) {
+	endpoints, err := hcsshim.HNSListEndpointRequest("GET", "", "")
+	if err != nil {
+		return nil, err
+	}
+	return endpoints, nil
 }

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -30,8 +30,6 @@ func TestHNS(t *testing.T) {
 var _ = BeforeSuite(func() {
 	err := common.HardResetHNS()
 	Expect(err).ToNot(HaveOccurred())
-	err = common.HardResetHNS()
-	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
@@ -129,7 +127,7 @@ var _ = Describe("HNS wrapper", func() {
 		Specify("HNS endpoint operations work", func() {
 			hnsEndpointConfig := &hcsshim.HNSEndpoint{
 				VirtualNetwork: testHnsNetID,
-				Name:           "dupadupa",
+				Name:           "ep_name",
 			}
 
 			endpointID, err := CreateHNSEndpoint(hnsEndpointConfig)

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -2,12 +2,16 @@ package hns
 
 import (
 	"flag"
+	"net"
 	"strings"
 	"testing"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim"
 	"github.com/codilime/contrail-windows-docker/common"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -26,6 +30,8 @@ func TestHNS(t *testing.T) {
 var _ = BeforeSuite(func() {
 	err := common.HardResetHNS()
 	Expect(err).ToNot(HaveOccurred())
+	err = common.HardResetHNS()
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
@@ -34,6 +40,13 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("HNS wrapper", func() {
+
+	const (
+		tenantName  = "agatka"
+		networkName = "test_net"
+		subnetCIDR  = "10.0.0.0/24"
+		defaultGW   = "10.0.0.1"
+	)
 
 	var originalNumNetworks int
 
@@ -48,30 +61,32 @@ var _ = Describe("HNS wrapper", func() {
 		testNetName := "TestNetwork"
 		testHnsNetID := ""
 
-		subnets := []hcsshim.Subnet{
-			{
-				AddressPrefix:  "1.1.1.0/24",
-				GatewayAddress: "1.1.1.1",
-			},
-		}
-		netConfiguration := &hcsshim.HNSNetwork{
-			Name:               testNetName,
-			Type:               "transparent",
-			Subnets:            subnets,
-			NetworkAdapterName: netAdapter,
-		}
-
 		BeforeEach(func() {
+			expectNumberOfEndpoints(0)
+
 			Expect(testHnsNetID).To(Equal(""))
-			var err error
-			testHnsNetID, err = CreateHNSNetwork(netConfiguration)
-			Expect(err).ToNot(HaveOccurred())
+			testHnsNetID = MockHNSNetwork(testNetName, netAdapter, subnetCIDR, defaultGW)
 			Expect(testHnsNetID).ToNot(Equal(""))
+
+			net, err := GetHNSNetwork(testHnsNetID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(net).ToNot(BeNil())
 		})
 
 		AfterEach(func() {
+			endpoints, err := ListHNSEndpoints()
+			Expect(err).ToNot(HaveOccurred())
+			if len(endpoints) > 0 {
+				// Cleanup lingering endpoints.
+				for _, ep := range endpoints {
+					err = DeleteHNSEndpoint(ep.Id)
+					Expect(err).ToNot(HaveOccurred())
+				}
+				expectNumberOfEndpoints(0)
+			}
+
 			Expect(testHnsNetID).ToNot(Equal(""))
-			err := DeleteHNSNetwork(testHnsNetID)
+			err = DeleteHNSNetwork(testHnsNetID)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = GetHNSNetwork(testHnsNetID)
 			Expect(err).To(HaveOccurred())
@@ -114,6 +129,7 @@ var _ = Describe("HNS wrapper", func() {
 		Specify("HNS endpoint operations work", func() {
 			hnsEndpointConfig := &hcsshim.HNSEndpoint{
 				VirtualNetwork: testHnsNetID,
+				Name:           "dupadupa",
 			}
 
 			endpointID, err := CreateHNSEndpoint(hnsEndpointConfig)
@@ -124,12 +140,123 @@ var _ = Describe("HNS wrapper", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(endpoint).ToNot(BeNil())
 
+			expectNumberOfEndpoints(1)
+
+			log.Infoln(endpoint)
+
 			err = DeleteHNSEndpoint(endpointID)
 			Expect(err).ToNot(HaveOccurred())
 
 			endpoint, err = GetHNSEndpoint(endpointID)
 			Expect(err).To(HaveOccurred())
 			Expect(endpoint).To(BeNil())
+		})
+
+		Specify("Listing HNS endpoints works", func() {
+			hnsEndpointConfig := &hcsshim.HNSEndpoint{
+				VirtualNetwork: testHnsNetID,
+			}
+
+			endpointsList, err := ListHNSEndpoints()
+			Expect(err).ToNot(HaveOccurred())
+			numEndpointsOriginal := len(endpointsList)
+
+			var endpoints [2]string
+			for i := 0; i < 2; i++ {
+				endpoints[i], err = CreateHNSEndpoint(hnsEndpointConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(endpoints[i]).ToNot(Equal(""))
+			}
+
+			expectNumberOfEndpoints(numEndpointsOriginal + 2)
+
+			for _, ep := range endpoints {
+				err = DeleteHNSEndpoint(ep)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			expectNumberOfEndpoints(numEndpointsOriginal)
+		})
+
+		Specify("Creating endpoint in same subnet works", func() {
+			_, err := CreateHNSEndpoint(&hcsshim.HNSEndpoint{
+				VirtualNetwork: testHnsNetID,
+				IPAddress:      net.ParseIP("10.0.0.4"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			expectNumberOfEndpoints(1)
+		})
+
+		Specify("Creating endpoint in different subnet fails", func() {
+			_, err := CreateHNSEndpoint(&hcsshim.HNSEndpoint{
+				VirtualNetwork: testHnsNetID,
+				IPAddress:      net.ParseIP("10.1.0.4"),
+			})
+			Expect(err).To(HaveOccurred())
+			expectNumberOfEndpoints(0)
+		})
+
+		Specify("Creating two endpoints with same IP works in same subnet fails", func() {
+			_, err := CreateHNSEndpoint(&hcsshim.HNSEndpoint{
+				VirtualNetwork: testHnsNetID,
+				IPAddress:      net.ParseIP("10.0.0.4"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = CreateHNSEndpoint(&hcsshim.HNSEndpoint{
+				VirtualNetwork: testHnsNetID,
+				IPAddress:      net.ParseIP("10.0.0.4"),
+			})
+			Expect(err).To(HaveOccurred())
+
+			expectNumberOfEndpoints(1)
+		})
+
+		type MACTestCase struct {
+			MAC        string
+			shouldFail bool
+		}
+		DescribeTable("Creating an endpoint with specific MACs",
+			func(t MACTestCase) {
+				epID, err := CreateHNSEndpoint(&hcsshim.HNSEndpoint{
+					VirtualNetwork: testHnsNetID,
+					MacAddress:     t.MAC,
+				})
+				if t.shouldFail {
+					Expect(err).To(HaveOccurred())
+					expectNumberOfEndpoints(0)
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+					ep, err := GetHNSEndpoint(epID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ep.MacAddress).To(Equal(t.MAC))
+					expectNumberOfEndpoints(1)
+				}
+			},
+			Entry("11-22-33-44-55-66 works", MACTestCase{
+				MAC:        "11-22-33-44-55-66",
+				shouldFail: false,
+			}),
+			Entry("AA-BB-CC-DD-EE-FF works", MACTestCase{
+				MAC:        "AA-BB-CC-DD-EE-FF",
+				shouldFail: false,
+			}),
+			Entry("XX-YY-11-22-33-44 fails", MACTestCase{
+				MAC:        "XX-YY-11-22-33-44",
+				shouldFail: true,
+			}),
+		)
+
+		Specify("Creating multiple endpoints with conflicting MACs works", func() {
+			cfg := &hcsshim.HNSEndpoint{
+				VirtualNetwork: testHnsNetID,
+				MacAddress:     "11-22-33-44-55-66",
+			}
+			for i := 0; i < 3; i++ {
+				_, err := CreateHNSEndpoint(cfg)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			expectNumberOfEndpoints(3)
 		})
 	})
 
@@ -159,10 +286,16 @@ var _ = Describe("HNS wrapper", func() {
 			Expect(net).To(BeNil())
 		})
 
-		Specify("getting single HNS network by name returns error", func() {
+		Specify("getting single HNS network by name returns nil, nil", func() {
 			net, err := GetHNSNetworkByName("asdf")
-			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeNil())
 			Expect(net).To(BeNil())
 		})
 	})
 })
+
+func expectNumberOfEndpoints(num int) {
+	eps, err := ListHNSEndpoints()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(eps).To(HaveLen(num))
+}

--- a/hns/hns_test_helpers.go
+++ b/hns/hns_test_helpers.go
@@ -1,0 +1,34 @@
+package hns
+
+import (
+	"github.com/Microsoft/hcsshim"
+	. "github.com/onsi/gomega"
+)
+
+func MockHNSNetwork(name, netAdapter, subnetCIDR, defaultGW string) string {
+	subnets := []hcsshim.Subnet{
+		{
+			AddressPrefix:  subnetCIDR,
+			GatewayAddress: defaultGW,
+		},
+	}
+	netConfig := &hcsshim.HNSNetwork{
+		Name:               name,
+		Type:               "transparent",
+		NetworkAdapterName: netAdapter,
+		Subnets:            subnets,
+	}
+	var err error
+	netID, err := CreateHNSNetwork(netConfig)
+	Expect(err).ToNot(HaveOccurred())
+	return netID
+}
+
+func MockHNSEndpoint(netID string) string {
+	epConfig := &hcsshim.HNSEndpoint{
+		VirtualNetwork: netID,
+	}
+	epID, err := CreateHNSEndpoint(epConfig)
+	Expect(err).ToNot(HaveOccurred())
+	return epID
+}

--- a/hnsManager/hns_manager.go
+++ b/hnsManager/hns_manager.go
@@ -1,0 +1,88 @@
+package hnsManager
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim"
+	"github.com/codilime/contrail-windows-docker/common"
+	"github.com/codilime/contrail-windows-docker/hns"
+)
+
+// HNSManager manages HNS networks that are used by the driver.
+type HNSManager struct {
+	// TODO JW-154: store networks here that you know about. If not found here, look in HNS.
+	// for now, just look in HNS by name.
+}
+
+func contrailHNSNetName(tenant, netName string) string {
+	return fmt.Sprintf("%s:%s:%s", common.HNSNetworkPrefix, tenant, netName)
+}
+
+func (m *HNSManager) CreateNetwork(netAdapter, tenantName, networkName, subnetCIDR,
+	defaultGW string) (*hcsshim.HNSNetwork, error) {
+
+	hnsNetName := contrailHNSNetName(tenantName, networkName)
+
+	net, err := hns.GetHNSNetworkByName(hnsNetName)
+	if net != nil {
+		return nil, errors.New("Such HNS network already exists")
+	}
+
+	subnets := []hcsshim.Subnet{
+		{
+			AddressPrefix:  subnetCIDR,
+			GatewayAddress: defaultGW,
+		},
+	}
+
+	configuration := &hcsshim.HNSNetwork{
+		Name:               hnsNetName,
+		Type:               "transparent",
+		NetworkAdapterName: netAdapter,
+		Subnets:            subnets,
+	}
+
+	hnsNetworkID, err := hns.CreateHNSNetwork(configuration)
+	if err != nil {
+		return nil, err
+	}
+
+	hnsNetwork, err := hns.GetHNSNetwork(hnsNetworkID)
+	if err != nil {
+		return nil, err
+	}
+
+	return hnsNetwork, nil
+}
+
+func (m *HNSManager) GetNetwork(tenantName, networkName string) (*hcsshim.HNSNetwork, error) {
+	hnsNetName := contrailHNSNetName(tenantName, networkName)
+	hnsNetwork, err := hns.GetHNSNetworkByName(hnsNetName)
+	if err != nil {
+		return nil, err
+	}
+	if hnsNetwork == nil {
+		return nil, errors.New("Such HNS network does not exist")
+	}
+	return hnsNetwork, nil
+}
+
+func (m *HNSManager) DeleteNetwork(tenantName, networkName string) error {
+	hnsNetwork, err := m.GetNetwork(tenantName, networkName)
+	if err != nil {
+		return err
+	}
+	endpoints, err := hns.ListHNSEndpoints()
+	if err != nil {
+		return err
+	}
+
+	for _, ep := range endpoints {
+		if ep.VirtualNetworkName == hnsNetwork.Name {
+			return errors.New("Cannot delete network with active endpoints")
+		}
+	}
+
+	return hns.DeleteHNSNetwork(hnsNetwork.Id)
+}

--- a/hnsManager/hns_manager_test.go
+++ b/hnsManager/hns_manager_test.go
@@ -1,0 +1,121 @@
+package hnsManager
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/codilime/contrail-windows-docker/common"
+	"github.com/codilime/contrail-windows-docker/hns"
+	log "github.com/sirupsen/logrus"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var netAdapter string
+
+func init() {
+	flag.StringVar(&netAdapter, "netAdapter", "Ethernet0", "Ethernet adapter name to use")
+	log.SetLevel(log.DebugLevel)
+}
+
+func TestHNSManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HNS manager test suite")
+}
+
+var _ = BeforeSuite(func() {
+	err := common.HardResetHNS()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = Describe("HNS manager", func() {
+
+	const (
+		tenantName  = "agatka"
+		networkName = "test_net"
+		subnetCIDR  = "10.0.0.0/24"
+		defaultGW   = "10.0.0.1"
+	)
+
+	var hnsMgr *HNSManager
+
+	BeforeEach(func() {
+		hnsMgr = &HNSManager{}
+	})
+
+	AfterEach(func() {
+		err := common.HardResetHNS()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("specified network does not exist", func() {
+		Specify("creating a new HNS network works", func() {
+			_, err := hnsMgr.CreateNetwork(netAdapter, tenantName, networkName,
+				subnetCIDR, defaultGW)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		Specify("getting the HNS network returns error", func() {
+			net, err := hnsMgr.GetNetwork(tenantName, networkName)
+			Expect(err).To(HaveOccurred())
+			Expect(net).To(BeNil())
+		})
+	})
+
+	Context("specified network already exists", func() {
+		var existingNetID string
+		BeforeEach(func() {
+			hnsNetName := fmt.Sprintf("Contrail:%s:%s", tenantName, networkName)
+			existingNetID = hns.MockHNSNetwork(hnsNetName, netAdapter, subnetCIDR, defaultGW)
+		})
+
+		Specify("creating a new network with same params returns error", func() {
+			net, err := hnsMgr.CreateNetwork(netAdapter, tenantName, networkName,
+				subnetCIDR, defaultGW)
+			Expect(err).To(HaveOccurred())
+			Expect(net).To(BeNil())
+		})
+
+		Specify("getting the network returns it", func() {
+			net, err := hnsMgr.GetNetwork(tenantName, networkName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(net.Id).To(Equal(existingNetID))
+		})
+
+		Context("network has active endpoints", func() {
+			BeforeEach(func() {
+				eps, err := hns.ListHNSEndpoints()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(eps).To(BeEmpty())
+
+				_ = hns.MockHNSEndpoint(existingNetID)
+
+				eps, err = hns.ListHNSEndpoints()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(eps).ToNot(BeEmpty())
+			})
+
+			Specify("deleting the network returns error", func() {
+				err := hnsMgr.DeleteNetwork(tenantName, networkName)
+				Expect(err).To(HaveOccurred())
+
+				eps, err := hns.ListHNSEndpoints()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(eps).ToNot(BeEmpty())
+			})
+		})
+
+		Context("network has no active endpoints", func() {
+			Specify("deleting the network removes it", func() {
+				netsBefore, err := hns.ListHNSNetworks()
+				Expect(err).ToNot(HaveOccurred())
+				err = hnsMgr.DeleteNetwork(tenantName, networkName)
+				Expect(err).ToNot(HaveOccurred())
+				netsAfter, err := hns.ListHNSNetworks()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(netsBefore).To(HaveLen(len(netsAfter) + 1))
+			})
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -3,14 +3,12 @@ package main
 import (
 	"flag"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/codilime/contrail-windows-docker/controller"
 	"github.com/codilime/contrail-windows-docker/driver"
 )
 
 func main() {
-	var subnet = flag.String("subnet", "172.117.0.0/16", "subnet in CIDR format for HNS")
-	var gateway = flag.String("gateway", "172.117.0.1", "default gateway IP for HNS")
 	var adapter = flag.String("adapter", "Ethernet0",
 		"net adapter for HNS switch, must be physical")
 	var controllerIP = flag.String("controllerIP", "127.0.0.1",
@@ -24,21 +22,17 @@ func main() {
 	var err error
 
 	if c, err = controller.NewController(*controllerIP, *controllerPort); err != nil {
-		logrus.Error(err)
+		log.Error(err)
 		return
 	}
 
-	if d, err = driver.NewDriver(*subnet, *gateway, *adapter, c); err != nil {
-		logrus.Error(err)
+	if d, err = driver.NewDriver(*adapter, c); err != nil {
+		log.Error(err)
 		return
 	}
 
-	if err = d.Serve(); err != nil {
-		logrus.Error(err)
-		return
+	if err = d.StartServing(); err != nil {
+		log.Error(err)
 	}
-
-	if err = d.Teardown(); err != nil {
-		logrus.Error(err)
-	}
+	defer d.StopServing()
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"os"
+	"os/signal"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codilime/contrail-windows-docker/controller"
@@ -35,4 +37,8 @@ func main() {
 		log.Error(err)
 	}
 	defer d.StopServing()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	<-sigChan
 }

--- a/main.go
+++ b/main.go
@@ -28,11 +28,7 @@ func main() {
 		return
 	}
 
-	if d, err = driver.NewDriver(*adapter, c); err != nil {
-		log.Error(err)
-		return
-	}
-
+	d = driver.NewDriver(*adapter, c)
 	if err = d.StartServing(); err != nil {
 		log.Error(err)
 	}

--- a/vendor/github.com/Microsoft/hcsshim/hnsfuncs.go
+++ b/vendor/github.com/Microsoft/hcsshim/hnsfuncs.go
@@ -158,3 +158,13 @@ func HNSEndpointRequest(method, path, request string) (*HNSEndpoint, error) {
 
 	return endpoint, nil
 }
+
+func HNSListEndpointRequest(method, path, request string) ([]HNSEndpoint, error) {
+	var endpoints []HNSEndpoint
+	err := hnsCall(method, "/endpoints/"+path, request, &endpoints)
+	if err != nil {
+		return nil, err
+	}
+
+	return endpoints, nil
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,98 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, false)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, true)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	if pending {
+		ginkgo.PDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else if focused {
+		ginkgo.FDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else {
+		ginkgo.Describe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,81 @@
+package table
+
+import (
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description string
+	Parameters  []interface{}
+	Pending     bool
+	Focused     bool
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	if t.Pending {
+		ginkgo.PIt(t.Description)
+		return
+	}
+
+	values := []reflect.Value{}
+	for i, param := range t.Parameters {
+		var value reflect.Value
+
+		if param == nil {
+			inType := itBody.Type().In(i)
+			value = reflect.Zero(inType)
+		} else {
+			value = reflect.ValueOf(param)
+		}
+
+		values = append(values, value)
+	}
+
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		ginkgo.FIt(t.Description, body)
+	} else {
+		ginkgo.It(t.Description, body)
+	}
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, false}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, true}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -81,6 +81,12 @@
 			"revisionTime": "2016-11-10T18:03:13Z"
 		},
 		{
+			"checksumSHA1": "pDvMd0VIsg9lpRY6ToPPHchSkE8=",
+			"path": "github.com/onsi/ginkgo/extensions/table",
+			"revision": "bb93381d543b0e5725244abe752214a110791d01",
+			"revisionTime": "2017-01-26T06:20:08Z"
+		},
+		{
 			"checksumSHA1": "aLkBED7RUwstAO+u2MgUXUwOwPo=",
 			"path": "github.com/onsi/ginkgo/internal/codelocation",
 			"revision": "00054c0bb96fc880d4e0be1b90937fad438c5290",


### PR DESCRIPTION
Big PR because the functionality was pretty entangled and required some changes to HNS and controller handling.

Also, updated vendors because I refactored some tests to use "Tables" and required an extension to test framework.

- [ ] JW-44 Handle network create in Contrail
- [ ] JW-45 Handle endpoint create in Contrail
- [ ] JW-149 Handle network create in HNS
- [ ] JW-151 Handle endpoint create in HNS

bonus (needed it for end to end tests so I include it in this PR): 
- [ ] JW-190 driver should stop on Ctrl+C

Also, there is some logic on Deleting networks and endpoints, but JW-150 and JW-152 are not done yet. I needed some deletion logic to cleanup between tests.