### PR TITLE
JW-189 handle multiple subnets

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Juniper/contrail-go-api"
 	"github.com/Juniper/contrail-go-api/types"
-	log "github.com/sirupsen/logrus"
 	"github.com/codilime/contrail-windows-docker/common"
+	log "github.com/sirupsen/logrus"
 )
 
 type Info struct {
@@ -190,7 +190,7 @@ func (c *Controller) GetOrCreateInstance(vif *types.VirtualMachineInterface, con
 	return createdInstance, nil
 }
 
-func(c *Controller) GetExistingInterface(net *types.VirtualNetwork, tenantName,
+func (c *Controller) GetExistingInterface(net *types.VirtualNetwork, tenantName,
 	containerId string) (*types.VirtualMachineInterface, error) {
 
 	fqName := fmt.Sprintf("%s:%s:%s", common.DomainName, tenantName, containerId)
@@ -248,7 +248,7 @@ func (c *Controller) GetInterfaceMac(iface *types.VirtualMachineInterface) (stri
 }
 
 func (c *Controller) GetOrCreateInstanceIp(net *types.VirtualNetwork,
-	iface *types.VirtualMachineInterface) (*types.InstanceIp, error) {
+	iface *types.VirtualMachineInterface, subnetUuid string) (*types.InstanceIp, error) {
 	instIp, err := types.InstanceIpByName(c.ApiClient, iface.GetName())
 	if err == nil && instIp != nil {
 		return instIp, nil
@@ -256,6 +256,8 @@ func (c *Controller) GetOrCreateInstanceIp(net *types.VirtualNetwork,
 
 	instIp = &types.InstanceIp{}
 	instIp.SetName(iface.GetName())
+	instIp.SetSubnetUuid(subnetUuid)
+
 	err = instIp.AddVirtualNetwork(net)
 	if err != nil {
 		log.Errorf("Failed to add network to instanceIP object: %v", err)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -132,10 +132,8 @@ func (c *Controller) GetIpamSubnet(net *types.VirtualNetwork, CIDR string) (
 		thisCIDR := fmt.Sprintf("%s/%v", ipam.Subnet.IpPrefix,
 			ipam.Subnet.IpPrefixLen)
 
-		if CIDR != "" {
-			if thisCIDR == CIDR {
-				return &ipam, nil
-			}
+		if thisCIDR == CIDR {
+			return &ipam, nil
 		}
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -85,35 +85,69 @@ func (c *Controller) GetNetwork(tenantName, networkName string) (*types.VirtualN
 	return net, nil
 }
 
-func (c *Controller) GetIpamSubnet(net *types.VirtualNetwork) (*types.IpamSubnetType, error) {
+// GetIpamSubnet returns IPAM subnet of specified virtual network with specified CIDR.
+// If virtual network has only one subnet, CIDR is ignored.
+func (c *Controller) GetIpamSubnet(net *types.VirtualNetwork, CIDR string) (
+	*types.IpamSubnetType, error) {
+
+	if strings.HasPrefix(CIDR, "0.0.0.0") {
+		// this means that the user didn't provide a subnet
+		CIDR = ""
+	}
+
 	ipamReferences, err := net.GetNetworkIpamRefs()
 	if err != nil {
 		log.Errorf("Failed to get ipam references: %v", err)
 		return nil, err
 	}
-	if len(ipamReferences) == 0 {
-		err = errors.New("Ipam references list is empty")
+
+	var allIpamSubnets []types.IpamSubnetType
+	for _, ref := range ipamReferences {
+		attribute := ref.Attr
+		ipamSubnets := attribute.(types.VnSubnetsType).IpamSubnets
+		for _, ipamSubnet := range ipamSubnets {
+			allIpamSubnets = append(allIpamSubnets, ipamSubnet)
+		}
+	}
+
+	if len(allIpamSubnets) == 0 {
+		err = errors.New("No Ipam subnets found")
 		log.Error(err)
 		return nil, err
 	}
-	attribute := ipamReferences[0].Attr
-	ipamSubnets := attribute.(types.VnSubnetsType).IpamSubnets
-	if len(ipamSubnets) == 0 {
-		err = errors.New("Ipam subnets list is empty")
-		log.Error(err)
-		return nil, err
+
+	if CIDR == "" {
+		if len(allIpamSubnets) > 1 {
+			err = errors.New("Didn't specify subnet CIDR and there are multiple Contrail subnets")
+			log.Error(err)
+			return nil, err
+		}
+		// return the one and only subnet
+		return &allIpamSubnets[0], nil
 	}
-	return &ipamSubnets[0], nil
+
+	// there are multiple subnets to choose from
+	for _, ipam := range allIpamSubnets {
+
+		thisCIDR := fmt.Sprintf("%s/%v", ipam.Subnet.IpPrefix,
+			ipam.Subnet.IpPrefixLen)
+
+		if CIDR != "" {
+			if thisCIDR == CIDR {
+				return &ipam, nil
+			}
+		}
+	}
+
+	err = errors.New("Subnet with specified CIDR not found")
+	log.Error(err)
+	return nil, err
 }
 
-func (c *Controller) GetDefaultGatewayIp(net *types.VirtualNetwork) (string, error) {
-	subnet, err := c.GetIpamSubnet(net)
-	if err != nil {
-		return "", err
-	}
+func (c *Controller) GetDefaultGatewayIp(subnet *types.IpamSubnetType) (string, error) {
 	gw := subnet.DefaultGateway
 	if gw == "" {
-		err = errors.New("Default GW is empty")
+		err := errors.New("Default GW is empty")
 		log.Error(err)
 		return "", err
 	}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -2,8 +2,8 @@ package controller
 
 import (
 	"flag"
-	"testing"
 	"fmt"
+	"testing"
 
 	contrail "github.com/Juniper/contrail-go-api"
 	"github.com/Juniper/contrail-go-api/types"
@@ -306,7 +306,7 @@ var _ = Describe("Controller", func() {
 			It("returns existing vif", func() {
 				testInterface := CreateMockedInterface(client.ApiClient, testNetwork, tenantName,
 					containerID)
-				
+
 				iface, err := client.GetExistingInterface(testNetwork, tenantName, containerID)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(iface).ToNot(BeNil())
@@ -416,7 +416,7 @@ var _ = Describe("Controller", func() {
 					testInterface, testNetwork)
 			})
 			It("returns existing instance IP", func() {
-				instanceIP, err := client.GetOrCreateInstanceIp(testNetwork, testInterface)
+				instanceIP, err := client.GetOrCreateInstanceIp(testNetwork, testInterface, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(instanceIP).ToNot(BeNil())
 				Expect(instanceIP.GetUuid()).To(Equal(testInstanceIP.GetUuid()))
@@ -430,7 +430,7 @@ var _ = Describe("Controller", func() {
 		})
 		Context("when instance IP doesn't exist in Contrail", func() {
 			It("creates new instance IP", func() {
-				instanceIP, err := client.GetOrCreateInstanceIp(testNetwork, testInterface)
+				instanceIP, err := client.GetOrCreateInstanceIp(testNetwork, testInterface, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(instanceIP).ToNot(BeNil())
 				Expect(instanceIP.GetInstanceIpAddress()).ToNot(Equal(""))

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -140,44 +140,56 @@ var _ = Describe("Controller", func() {
 	})
 
 	Describe("getting Contrail subnet info", func() {
-		Context("network has subnet with default gateway", func() {
+		assertGettingSubnetFails := func(getTestedNet func() *types.VirtualNetwork,
+			CIDR string) func() {
+			return func() {
+				_, err := client.GetIpamSubnet(getTestedNet(), CIDR)
+				Expect(err).To(HaveOccurred())
+			}
+		}
+		Context("network has one subnet with default gateway", func() {
 			var testNetwork *types.VirtualNetwork
 			BeforeEach(func() {
 				testNetwork = CreateMockedNetwork(client.ApiClient, networkName, project)
 				AddSubnetWithDefaultGateway(client.ApiClient, subnetPrefix, defaultGW,
 					subnetMask, testNetwork)
 			})
-			Specify("getting default gw IP works", func() {
-				gwAddr, err := client.GetDefaultGatewayIp(testNetwork)
+			Specify("getting subnet meta works", func() {
+				ipam, err := client.GetIpamSubnet(testNetwork, "")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(gwAddr).ToNot(Equal(""))
-			})
-			Specify("getting subnet prefix and prefix len works", func() {
-				ipam, err := client.GetIpamSubnet(testNetwork)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(ipam.DefaultGateway).To(Equal(defaultGW))
 				Expect(ipam.Subnet.IpPrefix).To(Equal(subnetPrefix))
 				Expect(ipam.Subnet.IpPrefixLen).To(Equal(subnetMask))
 			})
+			Specify("getting subnet when specifying CIDR works", func() {
+				_, err := client.GetIpamSubnet(testNetwork, subnetCIDR)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			Specify("getting subnet when specifying CIDR not in Contrail fails",
+				assertGettingSubnetFails(func() *types.VirtualNetwork {
+					return testNetwork
+				}, "1.2.3.4/16"))
 		})
-		Context("network has subnet without default gateway", func() {
+		Context("network has one subnet without default gateway", func() {
 			var testNetwork *types.VirtualNetwork
 			BeforeEach(func() {
 				testNetwork = CreateMockedNetworkWithSubnet(client.ApiClient, networkName,
 					subnetCIDR, project)
 			})
 			Specify("getting default gw IP returns error", func() {
-				gwAddr, err := client.GetDefaultGatewayIp(testNetwork)
+				ipam, err := client.GetIpamSubnet(testNetwork, "")
+				Expect(err).ToNot(HaveOccurred())
 				if useActualController {
-					Expect(gwAddr).ToNot(Equal(""))
+					Expect(ipam.DefaultGateway).ToNot(Equal(""))
 					Expect(err).ToNot(HaveOccurred())
 				} else {
 					// mocked controller lacks some logic here
-					Expect(gwAddr).To(Equal(""))
+					Expect(ipam.DefaultGateway).To(Equal(""))
 					Expect(err).To(HaveOccurred())
 				}
 			})
 			Specify("getting subnet prefix and prefix len works", func() {
-				ipam, err := client.GetIpamSubnet(testNetwork)
+				ipam, err := client.GetIpamSubnet(testNetwork, "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ipam.Subnet.IpPrefix).To(Equal(subnetPrefix))
 				Expect(ipam.Subnet.IpPrefixLen).To(Equal(subnetMask))
@@ -188,15 +200,58 @@ var _ = Describe("Controller", func() {
 			BeforeEach(func() {
 				testNetwork = CreateMockedNetwork(client.ApiClient, networkName, project)
 			})
-			Specify("getting default gw IP returns error", func() {
-				gwAddr, err := client.GetDefaultGatewayIp(testNetwork)
-				Expect(err).To(HaveOccurred())
-				Expect(gwAddr).To(Equal(""))
+			Specify("getting subnet returns error",
+				assertGettingSubnetFails(func() *types.VirtualNetwork {
+					return testNetwork
+				}, ""))
+		})
+		Context("network has multiple subnets", func() {
+			var testNetwork *types.VirtualNetwork
+			const (
+				prefix1 = "10.10.10.0"
+				gw1     = "10.10.10.1"
+				cidr1   = "10.10.10.0/24"
+				prefix2 = "10.20.20.0"
+				gw2     = "10.20.20.1"
+				cidr2   = "10.20.20.0/24"
+			)
+			BeforeEach(func() {
+				testNetwork = CreateMockedNetwork(client.ApiClient, networkName, project)
+				AddSubnetWithDefaultGateway(client.ApiClient, prefix1, gw1, 24,
+					testNetwork)
+				AddSubnetWithDefaultGateway(client.ApiClient, prefix2, gw2, 24,
+					testNetwork)
 			})
-			Specify("getting subnet prefix and prefix len returns error", func() {
-				ipam, err := client.GetIpamSubnet(testNetwork)
-				Expect(err).To(HaveOccurred())
-				Expect(ipam).To(BeNil())
+			Context("user specified valid subnet", func() {
+				Specify("getting specific subnets works", func() {
+					ipam1, err := client.GetIpamSubnet(testNetwork, cidr1)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ipam1.DefaultGateway).To(Equal(gw1))
+
+					ipam2, err := client.GetIpamSubnet(testNetwork, cidr2)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ipam2.DefaultGateway).To(Equal(gw2))
+				})
+			})
+			Context("user didn't specify a subnet", func() {
+				Specify("getting subnet1 returns error",
+					assertGettingSubnetFails(func() *types.VirtualNetwork {
+						return testNetwork
+					}, ""))
+				Specify("getting subnet2 returns error",
+					assertGettingSubnetFails(func() *types.VirtualNetwork {
+						return testNetwork
+					}, ""))
+			})
+			Context("user specified invalid subnet", func() {
+				Specify("getting subnet1 returns error",
+					assertGettingSubnetFails(func() *types.VirtualNetwork {
+						return testNetwork
+					}, "10.12.13.0/24"))
+				Specify("getting subnet2 returns error",
+					assertGettingSubnetFails(func() *types.VirtualNetwork {
+						return testNetwork
+					}, "10.12.13.0/24"))
 			})
 		})
 	})

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -231,6 +231,8 @@ var _ = Describe("Controller", func() {
 					ipam2, err := client.GetIpamSubnet(testNetwork, cidr2)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ipam2.DefaultGateway).To(Equal(gw2))
+
+					Expect(ipam1.Subnet.IpPrefix).NotTo(Equal(ipam2.Subnet.IpPrefix))
 				})
 			})
 			Context("user didn't specify a subnet", func() {

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -343,6 +343,15 @@ var _ = Describe("HNS wrapper", func() {
 			}
 			expectNumberOfEndpoints(3)
 		})
+
+		Specify("Creating endpoint with name containing special characters works", func() {
+			cfg := &hcsshim.HNSEndpoint{
+				VirtualNetwork: testHnsNetID,
+				Name:           "A:B123/123",
+			}
+			_, err := CreateHNSEndpoint(cfg)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("HNS network doesn't exist", func() {

--- a/hnsManager/hns_manager.go
+++ b/hnsManager/hns_manager.go
@@ -16,14 +16,14 @@ type HNSManager struct {
 	// for now, just look in HNS by name.
 }
 
-func contrailHNSNetName(tenant, netName string) string {
-	return fmt.Sprintf("%s:%s:%s", common.HNSNetworkPrefix, tenant, netName)
+func contrailHNSNetName(tenant, netName, subnetCIDR string) string {
+	return fmt.Sprintf("%s:%s:%s:%s", common.HNSNetworkPrefix, tenant, netName, subnetCIDR)
 }
 
 func (m *HNSManager) CreateNetwork(netAdapter common.AdapterName, tenantName, networkName,
 	subnetCIDR, defaultGW string) (*hcsshim.HNSNetwork, error) {
 
-	hnsNetName := contrailHNSNetName(tenantName, networkName)
+	hnsNetName := contrailHNSNetName(tenantName, networkName, subnetCIDR)
 
 	net, err := hns.GetHNSNetworkByName(hnsNetName)
 	if net != nil {
@@ -57,8 +57,9 @@ func (m *HNSManager) CreateNetwork(netAdapter common.AdapterName, tenantName, ne
 	return hnsNetwork, nil
 }
 
-func (m *HNSManager) GetNetwork(tenantName, networkName string) (*hcsshim.HNSNetwork, error) {
-	hnsNetName := contrailHNSNetName(tenantName, networkName)
+func (m *HNSManager) GetNetwork(tenantName, networkName, subnetCIDR string) (*hcsshim.HNSNetwork,
+	error) {
+	hnsNetName := contrailHNSNetName(tenantName, networkName, subnetCIDR)
 	hnsNetwork, err := hns.GetHNSNetworkByName(hnsNetName)
 	if err != nil {
 		return nil, err
@@ -69,8 +70,8 @@ func (m *HNSManager) GetNetwork(tenantName, networkName string) (*hcsshim.HNSNet
 	return hnsNetwork, nil
 }
 
-func (m *HNSManager) DeleteNetwork(tenantName, networkName string) error {
-	hnsNetwork, err := m.GetNetwork(tenantName, networkName)
+func (m *HNSManager) DeleteNetwork(tenantName, networkName, subnetCIDR string) error {
+	hnsNetwork, err := m.GetNetwork(tenantName, networkName, subnetCIDR)
 	if err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (m *HNSManager) ListNetworks() ([]hcsshim.HNSNetwork, error) {
 	}
 	for _, net := range nets {
 		splitName := strings.Split(net.Name, ":")
-		if len(splitName) == 3 {
+		if len(splitName) == 4 {
 			if splitName[0] == common.HNSNetworkPrefix {
 				validNets = append(validNets, net)
 			}

--- a/hnsManager/hns_manager_test.go
+++ b/hnsManager/hns_manager_test.go
@@ -62,7 +62,7 @@ var _ = Describe("HNS manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		Specify("getting the HNS network returns error", func() {
-			net, err := hnsMgr.GetNetwork(tenantName, networkName)
+			net, err := hnsMgr.GetNetwork(tenantName, networkName, subnetCIDR)
 			Expect(err).To(HaveOccurred())
 			Expect(net).To(BeNil())
 		})
@@ -71,7 +71,7 @@ var _ = Describe("HNS manager", func() {
 	Context("specified network already exists", func() {
 		var existingNetID string
 		BeforeEach(func() {
-			hnsNetName := fmt.Sprintf("Contrail:%s:%s", tenantName, networkName)
+			hnsNetName := fmt.Sprintf("Contrail:%s:%s:%s", tenantName, networkName, subnetCIDR)
 			existingNetID = hns.MockHNSNetwork(common.AdapterName(netAdapter), hnsNetName,
 				subnetCIDR, defaultGW)
 		})
@@ -84,7 +84,7 @@ var _ = Describe("HNS manager", func() {
 		})
 
 		Specify("getting the network returns it", func() {
-			net, err := hnsMgr.GetNetwork(tenantName, networkName)
+			net, err := hnsMgr.GetNetwork(tenantName, networkName, subnetCIDR)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(net.Id).To(Equal(existingNetID))
 		})
@@ -103,7 +103,7 @@ var _ = Describe("HNS manager", func() {
 			})
 
 			Specify("deleting the network returns error", func() {
-				err := hnsMgr.DeleteNetwork(tenantName, networkName)
+				err := hnsMgr.DeleteNetwork(tenantName, networkName, subnetCIDR)
 				Expect(err).To(HaveOccurred())
 
 				eps, err := hns.ListHNSEndpoints()
@@ -116,7 +116,7 @@ var _ = Describe("HNS manager", func() {
 			Specify("deleting the network removes it", func() {
 				netsBefore, err := hns.ListHNSNetworks()
 				Expect(err).ToNot(HaveOccurred())
-				err = hnsMgr.DeleteNetwork(tenantName, networkName)
+				err = hnsMgr.DeleteNetwork(tenantName, networkName, subnetCIDR)
 				Expect(err).ToNot(HaveOccurred())
 				netsAfter, err := hns.ListHNSNetworks()
 				Expect(err).ToNot(HaveOccurred())
@@ -128,9 +128,11 @@ var _ = Describe("HNS manager", func() {
 	Describe("Listing Contrail networks", func() {
 		BeforeEach(func() {
 			names := []string{
-				fmt.Sprintf("Contrail:%s:%s", "tenant1", "netname1"),
-				fmt.Sprintf("Contrail:%s:%s", "tenant2", "netname2"),
+				fmt.Sprintf("Contrail:%s:%s:%s", "tenant1", "netname1", "1.2.3.4/24"),
+				fmt.Sprintf("Contrail:%s:%s:%s", "tenant2", "netname2", "2.3.4.5/24"),
 				fmt.Sprintf("Contrail:%s", "invalid_num_of_fields"),
+				fmt.Sprintf("Contrail:%s:%s", "invalid", "num_of_fields"),
+				fmt.Sprintf("Contrail:%s:%s:%s:%s", "invalid", "num", "of", "fields"),
 				"some_other_name",
 			}
 			for _, n := range names {


### PR DESCRIPTION
This PR allows the user to specify which contrail subnet (network can have multiple subnets) should be used as the subnet in docker and hns.

If contrail network has only one subnet, then everything is as it used to be. If it has multiple, user needs to specify it using ```--subnet``` parameter of ```docker network create``` command.

Right now, since it's kinda hard to modify HNS networks to accomodate multiple subnets (it can be done only upon creation AFAIK), we will use a single HNS network (and single Docker network) per single Contrail subnet. 