### PR TITLE
JW-204 Prepare dummy HNS network for HNS switch.

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -14,6 +14,10 @@ const (
 
 	// HNSNetworkPrefix is a prefix given too all HNS network names managed by the driver
 	HNSNetworkPrefix = "Contrail"
+
+	// RootNetworkName is a name of root HNS network created solely for the purpose of
+	// having a virtual switch
+	RootNetworkName = "ContrailRootNetwork"
 )
 
 // PluginSpecDir returns path to directory where docker daemon looks for plugin spec files.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -83,6 +83,34 @@ func (d *ContrailDriver) StartServing() error {
 
 	log.Infoln("Started serving on ", pipeAddr)
 
+	rootNetwork, err := hns.GetHNSNetworkByName(common.RootNetworkName)
+	if err != nil {
+		return err
+	}
+	if rootNetwork == nil {
+
+		subnets := []hcsshim.Subnet{
+			{
+				AddressPrefix:  "0.0.0.0/24",
+				GatewayAddress: "0.0.0.0",
+			},
+		}
+		configuration := &hcsshim.HNSNetwork{
+			Name:               common.RootNetworkName,
+			Type:               "transparent",
+			NetworkAdapterName: d.networkAdapter,
+			Subnets:            subnets,
+		}
+		rootNetID, err := hns.CreateHNSNetwork(configuration)
+		if err != nil {
+			return err
+		}
+
+		log.Infoln("Created root HNS network:", rootNetID)
+	} else {
+		log.Infoln("Existing root HNS network found:", rootNetwork.Id)
+	}
+
 	return nil
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -51,6 +51,11 @@ func NewDriver(adapter string, c *controller.Controller) *ContrailDriver {
 
 func (d *ContrailDriver) StartServing() error {
 
+	err := d.createRootNetwork()
+	if err != nil {
+		return err
+	}
+
 	pipeConfig := winio.PipeConfig{
 		// This will set permissions for Service, System, Adminstrator group and account to
 		// have full access
@@ -60,7 +65,6 @@ func (d *ContrailDriver) StartServing() error {
 		OutputBufferSize:   4096,
 	}
 
-	var err error
 	pipeAddr := "//./pipe/" + common.DriverName
 	if d.listener, err = winio.ListenPipe(pipeAddr, &pipeConfig); err != nil {
 		return err
@@ -83,6 +87,10 @@ func (d *ContrailDriver) StartServing() error {
 
 	log.Infoln("Started serving on ", pipeAddr)
 
+	return nil
+}
+
+func (d *ContrailDriver) createRootNetwork() error {
 	rootNetwork, err := hns.GetHNSNetworkByName(common.RootNetworkName)
 	if err != nil {
 		return err
@@ -110,7 +118,6 @@ func (d *ContrailDriver) StartServing() error {
 	} else {
 		log.Infoln("Existing root HNS network found:", rootNetwork.Id)
 	}
-
 	return nil
 }
 

--- a/hns/hns.go
+++ b/hns/hns.go
@@ -2,6 +2,7 @@ package hns
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/Microsoft/hcsshim"
 	log "github.com/Sirupsen/logrus"
@@ -20,6 +21,9 @@ func CreateHNSNetwork(configuration *hcsshim.HNSNetwork) (string, error) {
 		log.Errorln(err)
 		return "", err
 	}
+	// Annoying HNS issue, sleep as a workaround.
+	// https://github.com/Microsoft/hcsshim/issues/108
+	time.Sleep(time.Second * 2)
 	return response.Id, nil
 }
 

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -403,7 +403,7 @@ var _ = Describe("HNS race conditions workarounds", func() {
 		}
 		configuration := &hcsshim.HNSNetwork{
 			Type:               "transparent",
-			NetworkAdapterName: "Ethernet0",
+			NetworkAdapterName: netAdapter,
 			Subnets:            subnets,
 		}
 
@@ -457,7 +457,7 @@ var _ = Describe("HNS race conditions workarounds", func() {
 
 		configuration := &hcsshim.HNSNetwork{
 			Type:               "transparent",
-			NetworkAdapterName: "Ethernet0",
+			NetworkAdapterName: netAdapter,
 		}
 
 		Specify("error does not occur when we don't supply a subnet to new network", func() {

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -2,6 +2,7 @@ package hns
 
 import (
 	"flag"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -16,10 +17,20 @@ import (
 )
 
 var netAdapter string
+var controllerAddr string
+var controllerPort int
+var useActualController bool
 
 func init() {
 	flag.StringVar(&netAdapter, "netAdapter", "Ethernet0",
 		"Network adapter to connect HNS switch to")
+	flag.StringVar(&controllerAddr, "controllerAddr",
+		"10.7.0.54", "Contrail controller addr")
+	flag.IntVar(&controllerPort, "controllerPort", 8082, "Contrail controller port")
+	flag.BoolVar(&useActualController, "useActualController", true,
+		"Whether to use mocked controller or actual.")
+
+	log.SetLevel(log.DebugLevel)
 }
 
 func TestHNS(t *testing.T) {
@@ -37,14 +48,14 @@ var _ = AfterSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 })
 
-var _ = Describe("HNS wrapper", func() {
+const (
+	tenantName  = "agatka"
+	networkName = "test_net"
+	subnetCIDR  = "10.0.0.0/24"
+	defaultGW   = "10.0.0.1"
+)
 
-	const (
-		tenantName  = "agatka"
-		networkName = "test_net"
-		subnetCIDR  = "10.0.0.0/24"
-		defaultGW   = "10.0.0.1"
-	)
+var _ = Describe("HNS wrapper", func() {
 
 	var originalNumNetworks int
 
@@ -356,6 +367,109 @@ var _ = Describe("HNS wrapper", func() {
 			net, err := GetHNSNetworkByName("asdf")
 			Expect(err).To(BeNil())
 			Expect(net).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("HNS race conditions workarounds", func() {
+
+	var targetAddr string
+	const (
+		numTries = 20
+	)
+
+	BeforeEach(func() {
+		if !useActualController {
+			Skip("useActualController flag is false. Won't perform HNS race conditions test.")
+		}
+
+		targetAddr = fmt.Sprintf("%s:%v", controllerAddr, controllerPort)
+		err := common.HardResetHNS()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Specify("without HNS networks, connections work", func() {
+		_, err := net.Dial("tcp", targetAddr)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("subnet is specified in new HNS switch config", func() {
+
+		subnets := []hcsshim.Subnet{
+			{
+				AddressPrefix:  "10.0.0.0/24",
+				GatewayAddress: "10.0.0.1",
+			},
+		}
+		configuration := &hcsshim.HNSNetwork{
+			Type:               "transparent",
+			NetworkAdapterName: "Ethernet0",
+			Subnets:            subnets,
+		}
+
+		Specify("connections don't fail just after new HNS network is created/deleted", func() {
+			// net.Dial may fail with error:
+			// `dial tcp localhost:80: connectex: A socket operation was attempted to an
+			// unreachable network.`
+			for i := 0; i < numTries; i++ {
+				networkIDMsg := fmt.Sprintf("net%v", i)
+				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))
+				netID, err := CreateHNSNetwork(configuration)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				_, err = net.Dial("tcp", targetAddr)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+
+				By(fmt.Sprintf("HNS network %s was just deleted", networkIDMsg))
+				err = DeleteHNSNetwork(netID)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				_, err = net.Dial("tcp", targetAddr)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+			}
+		})
+
+		Specify("connections don't fail on subsequent HNS networks", func() {
+
+			var netIDs []string
+
+			for i := 0; i < numTries; i++ {
+				networkIDMsg := fmt.Sprintf("net%v", i)
+				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))
+				configuration.Name = networkIDMsg
+				netID, err := CreateHNSNetwork(configuration)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				netIDs = append(netIDs, netID)
+				_, err = net.Dial("tcp", targetAddr)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+			}
+
+			for i, netID := range netIDs {
+				networkIDMsg := fmt.Sprintf("net%v", i)
+				By(fmt.Sprintf("HNS network %s was just deleted", networkIDMsg))
+				err := DeleteHNSNetwork(netID)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				_, err = net.Dial("tcp", targetAddr)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+			}
+		})
+	})
+
+	Context("subnet is NOT specified in new HNS switch config", func() {
+
+		configuration := &hcsshim.HNSNetwork{
+			Type:               "transparent",
+			NetworkAdapterName: "Ethernet0",
+		}
+
+		Specify("error does not occur when we don't supply a subnet to new network", func() {
+			// CreateHNSNetwork may fail with error:
+			// `HNS failed with error : Unspecified error`
+			for i := 0; i < numTries; i++ {
+				networkIDMsg := fmt.Sprintf("net%v", i)
+				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))
+				netID, err := CreateHNSNetwork(configuration)
+				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				hcsshim.HNSNetworkRequest("DELETE", netID, "")
+			}
 		})
 	})
 })


### PR DESCRIPTION
This task seemed pretty easy, but I found 2 another, related HNS issues, mentioned in the code. To test it, I added some workarounds and their test cases. The workaround itself consists of a Sleep statement when creating a HNS network. Maybe we can replace it with some kind of polling of net adapters in the future (JW-218).