### PR TITLE
JW-311 Improve docker restart times

### DIFF
--- a/common/misc.go
+++ b/common/misc.go
@@ -50,10 +50,26 @@ func HardResetHNS() error {
 	return nil
 }
 
+func StopDocker() error {
+	log.Infoln("Stopping docker")
+	if err := callPowershell("Stop-Service", "docker"); err != nil {
+		return errors.New(fmt.Sprintf("When stopping docker: %s", err))
+	}
+	return nil
+}
+
+func StartDocker() error {
+	log.Infoln("Starting docker")
+	if err := callPowershell("Start-Service", "docker"); err != nil {
+		return errors.New(fmt.Sprintf("When starting docker: %s", err))
+	}
+	return nil
+}
+
 func RestartDocker() error {
 	log.Infoln("Restarting docker")
 	if err := callPowershell("Restart-Service", "docker"); err != nil {
-		return err
+		return errors.New(fmt.Sprintf("When restarting docker: %s", err))
 	}
 	return nil
 }

--- a/common/misc.go
+++ b/common/misc.go
@@ -50,22 +50,6 @@ func HardResetHNS() error {
 	return nil
 }
 
-func StopDocker() error {
-	log.Infoln("Stopping docker")
-	if err := callPowershell("Stop-Service", "docker"); err != nil {
-		return errors.New(fmt.Sprintf("When stopping docker: %s", err))
-	}
-	return nil
-}
-
-func StartDocker() error {
-	log.Infoln("Starting docker")
-	if err := callPowershell("Start-Service", "docker"); err != nil {
-		return errors.New(fmt.Sprintf("When starting docker: %s", err))
-	}
-	return nil
-}
-
 func RestartDocker() error {
 	log.Infoln("Restarting docker")
 	if err := callPowershell("Restart-Service", "docker"); err != nil {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -187,16 +187,13 @@ var _ = Describe("On requests from docker daemon", func() {
 	})
 	AfterEach(func() {
 		cleanupAllDockerNetworksAndContainers(docker)
-		err := common.StopDocker()
+		err := common.RestartDocker()
 		Expect(err).ToNot(HaveOccurred())
 
 		err = contrailDriver.StopServing()
 		Expect(err).ToNot(HaveOccurred())
 
 		err = common.HardResetHNS()
-		Expect(err).ToNot(HaveOccurred())
-
-		err = common.StartDocker()
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
Originally, this PR was about shortening the time it would take for docker to Restart in CI, since it would take like 30 seconds - much longer than on "local" machine. It turns out, it would take a long time to create the default nat network. Solved it by adding "bridge": "none" in daemon.json of docker in CI.

Nonetheless, I introduced little fixes here and there, and would like to get it reviewed and merged.