### PR TITLE
JW-318 Poll root NIC IP instead of Sleep.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.coverprofile
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/common/config.go
+++ b/common/config.go
@@ -18,6 +18,13 @@ const (
 	// RootNetworkName is a name of root HNS network created solely for the purpose of
 	// having a virtual switch
 	RootNetworkName = "ContrailRootNetwork"
+
+	// AdapterReconnectTimeout is a time in ms to wait for adapter to reacquire IP after a new HNS
+	// network is created. https://github.com/Microsoft/hcsshim/issues/108
+	AdapterReconnectTimeout = 5000
+
+	// HNSTransparentInterfaceName is the name of transparent HNS vswitch interface name
+	HNSTransparentInterfaceName = "vEthernet (HNSTransparent)"
 )
 
 // PluginSpecDir returns path to directory where docker daemon looks for plugin spec files.

--- a/common/config.go
+++ b/common/config.go
@@ -21,7 +21,11 @@ const (
 
 	// AdapterReconnectTimeout is a time in ms to wait for adapter to reacquire IP after a new HNS
 	// network is created. https://github.com/Microsoft/hcsshim/issues/108
-	AdapterReconnectTimeout = 5000
+	AdapterReconnectTimeout = 15000
+
+	// AdapterPollingRate is rate (in ms) of polling of network adapter while waiting for it to
+	// reacquire IP. See AdapterReconnectTimeout
+	AdapterPollingRate = 300
 
 	// HNSTransparentInterfaceName is the name of transparent HNS vswitch interface name
 	HNSTransparentInterfaceName = "vEthernet (HNSTransparent)"

--- a/common/config.go
+++ b/common/config.go
@@ -19,12 +19,12 @@ const (
 	// having a virtual switch
 	RootNetworkName = "ContrailRootNetwork"
 
-	// AdapterReconnectTimeout is a time in ms to wait for adapter to reacquire IP after a new HNS
-	// network is created. https://github.com/Microsoft/hcsshim/issues/108
+	// AdapterReconnectTimeout is a time (in ms) to wait for adapter to reacquire IP after a new
+	// HNS network is created. https://github.com/Microsoft/hcsshim/issues/108
 	AdapterReconnectTimeout = 15000
 
 	// AdapterPollingRate is rate (in ms) of polling of network adapter while waiting for it to
-	// reacquire IP. See AdapterReconnectTimeout
+	// reacquire IP.
 	AdapterPollingRate = 300
 
 	// HNSTransparentInterfaceName is the name of transparent HNS vswitch interface name

--- a/common/misc.go
+++ b/common/misc.go
@@ -3,9 +3,11 @@ package common
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -56,4 +58,46 @@ func RestartDocker() error {
 		return err
 	}
 	return nil
+}
+
+func WaitForInterface(ifname string) error {
+	pollingStart := time.Now()
+	for {
+		queryStart := time.Now()
+		iface, err := net.InterfaceByName(ifname)
+		if err != nil {
+			log.Warnf("Error when getting interface %s, but maybe it will appear soon: %s",
+				ifname, err)
+		} else {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				return err
+			}
+
+			// We print query time because it turns out that above operations actually take quite a
+			// while (1-400ms), and the time depends (I think) on whether underlying interface
+			// configs are being changed. For example, query usually takes ~10ms, but if it's about
+			// to change, it can take up to 400ms. In other words, there must be some kind of mutex
+			// there. This information could be useful for debugging.
+			log.Debugf("Current %s addresses: %s. Query took %s", ifname,
+				addrs, time.Since(queryStart))
+
+			// We're essentialy waiting for adapter to reacquire IPv4 (that's how they do it
+			// in Microsoft: https://github.com/Microsoft/hcsshim/issues/108)
+			for _, addr := range addrs {
+				ip, err, _ := net.ParseCIDR(addr.String())
+				if err != nil {
+					if ip.To4() != nil {
+						log.Debugf("Waited %s for IP reacquisition", time.Since(pollingStart))
+						return nil
+					}
+				}
+			}
+		}
+
+		if time.Since(pollingStart) > time.Millisecond*AdapterReconnectTimeout {
+			return errors.New("Waited for net adapter to reconnect for too long.")
+		}
+		time.Sleep(time.Millisecond * AdapterPollingRate)
+	}
 }

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -62,9 +62,9 @@ var _ = AfterSuite(func() {
 })
 
 func cleanupAll() {
-	err := common.HardResetHNS()
+	err := common.RestartDocker()
 	Expect(err).ToNot(HaveOccurred())
-	err = common.RestartDocker()
+	err = common.HardResetHNS()
 	Expect(err).ToNot(HaveOccurred())
 
 	docker := getDockerClient()

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -66,6 +66,8 @@ func cleanupAll() {
 	Expect(err).ToNot(HaveOccurred())
 	err = common.HardResetHNS()
 	Expect(err).ToNot(HaveOccurred())
+	err = common.WaitForInterface(netAdapter)
+	Expect(err).ToNot(HaveOccurred())
 
 	docker := getDockerClient()
 	cleanupAllDockerNetworksAndContainers(docker)
@@ -191,6 +193,9 @@ var _ = Describe("On requests from docker daemon", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		err = common.HardResetHNS()
+		Expect(err).ToNot(HaveOccurred())
+
+		err = common.WaitForInterface(netAdapter)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/hns/hns.go
+++ b/hns/hns.go
@@ -2,9 +2,6 @@ package hns
 
 import (
 	"encoding/json"
-	"errors"
-	"net"
-	"time"
 
 	"github.com/Microsoft/hcsshim"
 	log "github.com/Sirupsen/logrus"
@@ -30,7 +27,7 @@ func CreateHNSNetwork(configuration *hcsshim.HNSNetwork) (string, error) {
 	// specified network adapter. This adapter will temporarily lose network connectivity
 	// while it reacquires IPv4. We need to wait for it.
 	// https://github.com/Microsoft/hcsshim/issues/108
-	if err := waitForInterface(common.HNSTransparentInterfaceName); err != nil {
+	if err := common.WaitForInterface(common.HNSTransparentInterfaceName); err != nil {
 		log.Errorln(err)
 		return "", err
 	}
@@ -73,55 +70,13 @@ func DeleteHNSNetwork(hnsID string) error {
 		// also deleted. During this period, the adapter will temporarily lose network
 		// connectivity while it reacquires IPv4. We need to wait for it.
 		// https://github.com/Microsoft/hcsshim/issues/95
-		if err := waitForInterface(toDelete.NetworkAdapterName); err != nil {
+		if err := common.WaitForInterface(toDelete.NetworkAdapterName); err != nil {
 			log.Errorln(err)
 			return err
 		}
 	}
 
 	return nil
-}
-
-func waitForInterface(ifname string) error {
-	pollingStart := time.Now()
-	for {
-		queryStart := time.Now()
-		iface, err := net.InterfaceByName(ifname)
-		if err != nil {
-			log.Warnf("Error when getting interface %s, but maybe it will appear soon: %s",
-				ifname, err)
-		} else {
-			addrs, err := iface.Addrs()
-			if err != nil {
-				return err
-			}
-
-			// We print query time because it turns out that above operations actually take quite a
-			// while (1-400ms), and the time depends (I think) on whether underlying interface
-			// configs are being changed. For example, query usually takes ~10ms, but if it's about
-			// to change, it can take up to 400ms. In other words, there must be some kind of mutex
-			// there. This information could be useful for debugging.
-			log.Debugf("Current %s addresses: %s. Query took %s", ifname,
-				addrs, time.Since(queryStart))
-
-			// We're essentialy waiting for adapter to reacquire IPv4 (that's how they do it
-			// in Microsoft: https://github.com/Microsoft/hcsshim/issues/108)
-			for _, addr := range addrs {
-				ip, err, _ := net.ParseCIDR(addr.String())
-				if err != nil {
-					if ip.To4() != nil {
-						log.Debugf("Waited %s for IP reacquisition", time.Since(pollingStart))
-						return nil
-					}
-				}
-			}
-		}
-
-		if time.Since(pollingStart) > time.Millisecond*common.AdapterReconnectTimeout {
-			return errors.New("Waited for net adapter to reconnect for too long.")
-		}
-		time.Sleep(time.Millisecond * common.AdapterPollingRate)
-	}
 }
 
 func ListHNSNetworks() ([]hcsshim.HNSNetwork, error) {

--- a/hns/hns.go
+++ b/hns/hns.go
@@ -52,7 +52,7 @@ func waitForInterface() error {
 		}
 
 		// We print query time because it turns out that above operations actually take quite a
-		// while (from 5-400ms), and the time depends (I think) if underlying interface configs
+		// while (1-400ms), and the time depends (I think) on whether underlying interface configs
 		// are being changed. For example, query usually takes ~10ms, but if it's about to change,
 		// it can take up to 400ms. In other words, there must be some kind of mutex there.
 		// This information could be useful for debugging.

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -407,9 +407,8 @@ var _ = Describe("HNS race conditions workarounds", func() {
 			},
 		}
 		configuration := &hcsshim.HNSNetwork{
-			Type:               "transparent",
-			NetworkAdapterName: netAdapter,
-			Subnets:            subnets,
+			Type:    "transparent",
+			Subnets: subnets,
 		}
 
 		Specify("connections don't fail just after new HNS network is created/deleted", func() {
@@ -475,8 +474,7 @@ var _ = Describe("HNS race conditions workarounds", func() {
 	Context("subnet is NOT specified in new HNS switch config", func() {
 
 		configuration := &hcsshim.HNSNetwork{
-			Type:               "transparent",
-			NetworkAdapterName: netAdapter,
+			Type: "transparent",
 		}
 
 		Specify("error does not occur when we don't supply a subnet to new network", func() {

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -417,21 +417,22 @@ var _ = Describe("HNS race conditions workarounds", func() {
 			// unreachable network.`
 			configuration.NetworkAdapterName = netAdapter
 			for i := 0; i < numTries; i++ {
-				networkIDMsg := fmt.Sprintf("net%v", i)
-				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))
+				name := fmt.Sprintf("net%v", i)
+				configuration.Name = name
+				By(fmt.Sprintf("Creating HNS network %s", name))
 				netID, err := CreateHNSNetwork(configuration)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				conn, err := net.Dial("tcp", targetAddr)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				if conn != nil {
 					conn.Close()
 				}
 
-				By(fmt.Sprintf("HNS network %s was just deleted", networkIDMsg))
+				By(fmt.Sprintf("Deleting HNS network %s", name))
 				err = DeleteHNSNetwork(netID)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				conn, err = net.Dial("tcp", targetAddr)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				if conn != nil {
 					conn.Close()
 				}
@@ -444,26 +445,26 @@ var _ = Describe("HNS race conditions workarounds", func() {
 			configuration.NetworkAdapterName = netAdapter
 
 			for i := 0; i < numTries; i++ {
-				networkIDMsg := fmt.Sprintf("net%v", i)
-				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))
-				configuration.Name = networkIDMsg
+				name := fmt.Sprintf("net%v", i)
+				configuration.Name = name
+				By(fmt.Sprintf("Creating HNS network %s", name))
 				netID, err := CreateHNSNetwork(configuration)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				netIDs = append(netIDs, netID)
 				conn, err := net.Dial("tcp", targetAddr)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				if conn != nil {
 					conn.Close()
 				}
 			}
 
 			for i, netID := range netIDs {
-				networkIDMsg := fmt.Sprintf("net%v", i)
-				By(fmt.Sprintf("HNS network %s was just deleted", networkIDMsg))
+				name := fmt.Sprintf("net%v", i)
+				By(fmt.Sprintf("Deleting HNS network %s", name))
 				err := DeleteHNSNetwork(netID)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				conn, err := net.Dial("tcp", targetAddr)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				if conn != nil {
 					conn.Close()
 				}
@@ -482,10 +483,11 @@ var _ = Describe("HNS race conditions workarounds", func() {
 			// `HNS failed with error : Unspecified error`
 			configuration.NetworkAdapterName = netAdapter
 			for i := 0; i < numTries; i++ {
-				networkIDMsg := fmt.Sprintf("net%v", i)
-				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))
+				name := fmt.Sprintf("net%v", i)
+				configuration.Name = name
+				By(fmt.Sprintf("Creating HNS network %s", name))
 				netID, err := CreateHNSNetwork(configuration)
-				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				Expect(err).ToNot(HaveOccurred(), name)
 				hcsshim.HNSNetworkRequest("DELETE", netID, "")
 			}
 		})

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -43,10 +43,14 @@ func TestHNS(t *testing.T) {
 var _ = BeforeSuite(func() {
 	err := common.HardResetHNS()
 	Expect(err).ToNot(HaveOccurred())
+	err = common.WaitForInterface(netAdapter)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
 	err := common.HardResetHNS()
+	Expect(err).ToNot(HaveOccurred())
+	err = common.WaitForInterface(netAdapter)
 	Expect(err).ToNot(HaveOccurred())
 })
 
@@ -387,6 +391,8 @@ var _ = Describe("HNS race conditions workarounds", func() {
 
 		targetAddr = fmt.Sprintf("%s:%v", controllerAddr, controllerPort)
 		err := common.HardResetHNS()
+		Expect(err).ToNot(HaveOccurred())
+		err = common.WaitForInterface(netAdapter)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/hns/hns_test.go
+++ b/hns/hns_test.go
@@ -391,8 +391,11 @@ var _ = Describe("HNS race conditions workarounds", func() {
 	})
 
 	Specify("without HNS networks, connections work", func() {
-		_, err := net.Dial("tcp", targetAddr)
+		conn, err := net.Dial("tcp", targetAddr)
 		Expect(err).ToNot(HaveOccurred())
+		if conn != nil {
+			conn.Close()
+		}
 	})
 
 	Context("subnet is specified in new HNS switch config", func() {
@@ -413,25 +416,33 @@ var _ = Describe("HNS race conditions workarounds", func() {
 			// net.Dial may fail with error:
 			// `dial tcp localhost:80: connectex: A socket operation was attempted to an
 			// unreachable network.`
+			configuration.NetworkAdapterName = netAdapter
 			for i := 0; i < numTries; i++ {
 				networkIDMsg := fmt.Sprintf("net%v", i)
 				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))
 				netID, err := CreateHNSNetwork(configuration)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
-				_, err = net.Dial("tcp", targetAddr)
+				conn, err := net.Dial("tcp", targetAddr)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				if conn != nil {
+					conn.Close()
+				}
 
 				By(fmt.Sprintf("HNS network %s was just deleted", networkIDMsg))
 				err = DeleteHNSNetwork(netID)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
-				_, err = net.Dial("tcp", targetAddr)
+				conn, err = net.Dial("tcp", targetAddr)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				if conn != nil {
+					conn.Close()
+				}
 			}
 		})
 
 		Specify("connections don't fail on subsequent HNS networks", func() {
 
 			var netIDs []string
+			configuration.NetworkAdapterName = netAdapter
 
 			for i := 0; i < numTries; i++ {
 				networkIDMsg := fmt.Sprintf("net%v", i)
@@ -440,8 +451,11 @@ var _ = Describe("HNS race conditions workarounds", func() {
 				netID, err := CreateHNSNetwork(configuration)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
 				netIDs = append(netIDs, netID)
-				_, err = net.Dial("tcp", targetAddr)
+				conn, err := net.Dial("tcp", targetAddr)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				if conn != nil {
+					conn.Close()
+				}
 			}
 
 			for i, netID := range netIDs {
@@ -449,8 +463,11 @@ var _ = Describe("HNS race conditions workarounds", func() {
 				By(fmt.Sprintf("HNS network %s was just deleted", networkIDMsg))
 				err := DeleteHNSNetwork(netID)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
-				_, err = net.Dial("tcp", targetAddr)
+				conn, err := net.Dial("tcp", targetAddr)
 				Expect(err).ToNot(HaveOccurred(), networkIDMsg)
+				if conn != nil {
+					conn.Close()
+				}
 			}
 		})
 	})
@@ -465,6 +482,7 @@ var _ = Describe("HNS race conditions workarounds", func() {
 		Specify("error does not occur when we don't supply a subnet to new network", func() {
 			// CreateHNSNetwork may fail with error:
 			// `HNS failed with error : Unspecified error`
+			configuration.NetworkAdapterName = netAdapter
 			for i := 0; i < numTries; i++ {
 				networkIDMsg := fmt.Sprintf("net%v", i)
 				By(fmt.Sprintf("HNS network %s was just created", networkIDMsg))

--- a/hnsManager/hns_manager_test.go
+++ b/hnsManager/hns_manager_test.go
@@ -29,6 +29,8 @@ func TestHNSManager(t *testing.T) {
 var _ = BeforeSuite(func() {
 	err := common.HardResetHNS()
 	Expect(err).ToNot(HaveOccurred())
+	err = common.WaitForInterface(netAdapter)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = Describe("HNS manager", func() {
@@ -48,6 +50,8 @@ var _ = Describe("HNS manager", func() {
 
 	AfterEach(func() {
 		err := common.HardResetHNS()
+		Expect(err).ToNot(HaveOccurred())
+		err = common.WaitForInterface(netAdapter)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
Uses polling of adapter's IPv4 instead of Sleeping for an arbitrary amount of time. 