### PR TITLE
JW-318 connectex error between tests

### DIFF
--- a/common/misc.go
+++ b/common/misc.go
@@ -55,7 +55,7 @@ func HardResetHNS() error {
 func RestartDocker() error {
 	log.Infoln("Restarting docker")
 	if err := callPowershell("Restart-Service", "docker"); err != nil {
-		return err
+		return errors.New(fmt.Sprintf("When restarting docker: %s", err))
 	}
 	return nil
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -160,7 +160,7 @@ func (d *ContrailDriver) StopServing() error {
 		log.Errorln(err)
 		return err
 	}
-
+	time.Sleep(time.Second * 1)
 	log.Infoln("Stopped serving")
 
 	return nil

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -160,7 +160,7 @@ func (d *ContrailDriver) StopServing() error {
 		log.Errorln(err)
 		return err
 	}
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 10)
 	log.Infoln("Stopped serving")
 
 	return nil

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -103,15 +103,16 @@ func (d *ContrailDriver) StartServing() error {
 	go h.Serve(d.listener)
 
 	// wait for listener goroutine to spin up
-	timeout := time.Second * 5
-	conn, err := winio.DialPipe(d.pipeAddr, &timeout)
-	if err != nil {
-		return err
-	}
-	if conn != nil {
-		conn.Close()
-	}
+	// timeout := time.Second * 5
+	// conn, err := winio.DialPipe(d.pipeAddr, &timeout)
+	// if err != nil {
+	// 	return err
+	// }
+	// if conn != nil {
+	// 	conn.Close()
+	// }
 
+	time.Sleep(time.Second * 1)
 	log.Infoln("Started serving on ", d.pipeAddr)
 
 	return nil

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -80,6 +80,7 @@ func (d *ContrailDriver) StartServing() error {
 					return err
 				}
 				log.Warn("Got error when trying to create pipe listener, retrying...:", err)
+				time.Sleep(time.Second * 1)
 				retryCnt++
 			default:
 				return err

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -97,7 +97,9 @@ var _ = Describe("Contrail Network Driver", func() {
 
 		conn, err := sockets.DialPipe("//./pipe/"+common.DriverName, timeout)
 		Expect(err).ToNot(HaveOccurred())
-		conn.Close()
+		if conn != nil {
+			conn.Close()
+		}
 
 		err = contrailDriver.StopServing()
 		Expect(err).ToNot(HaveOccurred())

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -95,15 +95,18 @@ var _ = Describe("Contrail Network Driver", func() {
 		err := contrailDriver.StartServing()
 		Expect(err).ToNot(HaveOccurred())
 
-		d, err := sockets.DialPipe("//./pipe/"+common.DriverName, timeout)
+		conn, err := sockets.DialPipe("//./pipe/"+common.DriverName, timeout)
 		Expect(err).ToNot(HaveOccurred())
-		d.Close()
+		conn.Close()
 
 		err = contrailDriver.StopServing()
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = sockets.DialPipe("//./pipe/"+common.DriverName, timeout)
+		conn, err = sockets.DialPipe("//./pipe/"+common.DriverName, timeout)
 		Expect(err).To(HaveOccurred())
+		if conn != nil {
+			conn.Close()
+		}
 	})
 
 	It("creates a spec file for duration of listening", func() {
@@ -780,12 +783,14 @@ func removeDockerNetwork(docker *dockerClient.Client, dockerNetID string) error 
 }
 
 func cleanupAllDockerNetworksAndContainers(docker *dockerClient.Client) {
+	log.Infoln("Cleaning up docker containers")
 	containers, err := docker.ContainerList(context.Background(), dockerTypes.ContainerListOptions{All: true})
 	Expect(err).ToNot(HaveOccurred())
 	for _, c := range containers {
 		log.Debugln("Stopping and removing container", c.ID)
 		stopAndRemoveDockerContainer(docker, c.ID)
 	}
+	log.Infoln("Cleaning up docker networks")
 	nets, err := docker.NetworkList(context.Background(), dockerTypes.NetworkListOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	for _, net := range nets {


### PR DESCRIPTION
Actually wait for driver pipe listener to start/stop, instead of sleeping.