### PR TITLE
JW-330 Pipe access denied

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -29,6 +29,12 @@ const (
 
 	// HNSTransparentInterfaceName is the name of transparent HNS vswitch interface name
 	HNSTransparentInterfaceName = "vEthernet (HNSTransparent)"
+
+	// PipePollingTimeout is time (in ms) to wait for named pipe to appear in the filesystem
+	PipePollingTimeout = 15000
+
+	// PipePollingRate is rate (in ms) of polling named pipe if it appeared in the filesystem yet
+	PipePollingRate = 300
 )
 
 // PluginSpecDir returns path to directory where docker daemon looks for plugin spec files.

--- a/common/config.go
+++ b/common/config.go
@@ -30,10 +30,12 @@ const (
 	// HNSTransparentInterfaceName is the name of transparent HNS vswitch interface name
 	HNSTransparentInterfaceName = "vEthernet (HNSTransparent)"
 
-	// PipePollingTimeout is time (in ms) to wait for named pipe to appear in the filesystem
+	// PipePollingTimeout is time (in ms) to wait for named pipe to appear/disappear in the
+	// filesystem
 	PipePollingTimeout = 15000
 
-	// PipePollingRate is rate (in ms) of polling named pipe if it appeared in the filesystem yet
+	// PipePollingRate is rate (in ms) of polling named pipe if it appeared/disappeared in the
+	// filesystem yet
 	PipePollingRate = 300
 )
 

--- a/common/config.go
+++ b/common/config.go
@@ -32,7 +32,7 @@ const (
 
 	// PipePollingTimeout is time (in ms) to wait for named pipe to appear/disappear in the
 	// filesystem
-	PipePollingTimeout = 15000
+	PipePollingTimeout = 5000
 
 	// PipePollingRate is rate (in ms) of polling named pipe if it appeared/disappeared in the
 	// filesystem yet

--- a/common/misc.go
+++ b/common/misc.go
@@ -55,7 +55,7 @@ func HardResetHNS() error {
 func RestartDocker() error {
 	log.Infoln("Restarting docker")
 	if err := callPowershell("Restart-Service", "docker"); err != nil {
-		return err
+		return errors.New(fmt.Sprintf("When restarting docker: %s", err))
 	}
 	return nil
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -537,7 +537,7 @@ func (d *ContrailDriver) waitUntilPipeDialable() error {
 	timeStarted := time.Now()
 	for {
 		if time.Since(timeStarted) > common.PipePollingTimeout {
-			return errors.New("Waited for pipe file for too long.")
+			return errors.New("Waited for pipe to be dialable for too long.")
 		}
 
 		timeout := time.Second * 5

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -513,7 +513,7 @@ func (d *ContrailDriver) waitForPipeToStop() error {
 func (d *ContrailDriver) waitForPipe(waitUntilExists bool) error {
 	timeStarted := time.Now()
 	for {
-		if time.Since(timeStarted) > common.PipePollingTimeout {
+		if time.Since(timeStarted) > time.Millisecond*common.PipePollingTimeout {
 			return errors.New("Waited for pipe file for too long.")
 		}
 
@@ -536,7 +536,7 @@ func (d *ContrailDriver) waitForPipe(waitUntilExists bool) error {
 func (d *ContrailDriver) waitUntilPipeDialable() error {
 	timeStarted := time.Now()
 	for {
-		if time.Since(timeStarted) > common.PipePollingTimeout {
+		if time.Since(timeStarted) > time.Millisecond*common.PipePollingTimeout {
 			return errors.New("Waited for pipe to be dialable for too long.")
 		}
 
@@ -549,7 +549,6 @@ func (d *ContrailDriver) waitUntilPipeDialable() error {
 
 		time.Sleep(time.Millisecond * common.PipePollingRate)
 	}
-	return nil
 }
 
 func (d *ContrailDriver) networkMetaFromDockerNetwork(dockerNetID string) (*NetworkMeta,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -530,6 +530,8 @@ func (d *ContrailDriver) waitForPipe(waitUntilExists bool) error {
 		return d.waitUntilPipeDialable()
 	}
 
+	time.Sleep(time.Second * 1)
+
 	return nil
 }
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -116,7 +116,7 @@ func (d *ContrailDriver) StopServing() error {
 	}
 
 	if err := d.waitForPipeToStop(); err != nil {
-		return err
+		log.Warnf("Failed to properly close named pipe, but will continue anyways: %s", err)
 	}
 
 	log.Infoln("Stopped serving")

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -90,6 +90,14 @@ var _ = Describe("Contrail Network Driver", func() {
 	BeforeEach(func() {
 		contrailDriver, contrailController, project = startDriver()
 	})
+	AfterEach(func() {
+		if contrailDriver.IsServing {
+			err := contrailDriver.StopServing()
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		cleanupAll()
+	})
 
 	It("can start and stop listening on a named pipe", func() {
 		err := contrailDriver.StartServing()

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -134,6 +134,10 @@ var _ = Describe("Contrail Network Driver", func() {
 		docker := getDockerClient()
 		_ = createValidDockerNetwork(docker)
 
+		// we need to cleanup here, because otherwise docker keeps the named pipe file open,
+		// so we can't remove it
+		cleanupAllDockerNetworksAndContainers(docker)
+
 		err = contrailDriver.StopServing()
 		Expect(err).ToNot(HaveOccurred())
 

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -103,20 +103,16 @@ var _ = Describe("Contrail Network Driver", func() {
 		err := contrailDriver.StartServing()
 		Expect(err).ToNot(HaveOccurred())
 
-		conn, err := sockets.DialPipe("//./pipe/"+common.DriverName, timeout)
+		conn, err := sockets.DialPipe(contrailDriver.PipeAddr, timeout)
 		Expect(err).ToNot(HaveOccurred())
-		if conn != nil {
 			conn.Close()
-		}
 
 		err = contrailDriver.StopServing()
 		Expect(err).ToNot(HaveOccurred())
 
-		conn, err = sockets.DialPipe("//./pipe/"+common.DriverName, timeout)
+		conn, err = sockets.DialPipe(contrailDriver.PipeAddr, timeout)
 		Expect(err).To(HaveOccurred())
-		if conn != nil {
 			conn.Close()
-		}
 	})
 
 	It("creates a spec file for duration of listening", func() {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -105,14 +105,16 @@ var _ = Describe("Contrail Network Driver", func() {
 
 		conn, err := sockets.DialPipe(contrailDriver.PipeAddr, timeout)
 		Expect(err).ToNot(HaveOccurred())
-			conn.Close()
+		conn.Close()
 
 		err = contrailDriver.StopServing()
 		Expect(err).ToNot(HaveOccurred())
 
 		conn, err = sockets.DialPipe(contrailDriver.PipeAddr, timeout)
 		Expect(err).To(HaveOccurred())
+		if conn != nil {
 			conn.Close()
+		}
 	})
 
 	It("creates a spec file for duration of listening", func() {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -105,7 +105,9 @@ var _ = Describe("Contrail Network Driver", func() {
 
 		conn, err := sockets.DialPipe(contrailDriver.PipeAddr, timeout)
 		Expect(err).ToNot(HaveOccurred())
-		conn.Close()
+		if conn != nil {
+			conn.Close()
+		}
 
 		err = contrailDriver.StopServing()
 		Expect(err).ToNot(HaveOccurred())

--- a/vendor/github.com/Microsoft/go-winio/pipe.go
+++ b/vendor/github.com/Microsoft/go-winio/pipe.go
@@ -275,8 +275,8 @@ func (l *win32PipeListener) listenerRoutine() {
 				case <-l.closeCh:
 					// Abort the connect request by closing the handle.
 					p.Close()
-					p = nil
 					err = <-ch
+					p = nil
 					if err == nil || err == ErrFileClosed {
 						err = ErrPipeListenerClosed
 					}


### PR DESCRIPTION
Attempts to fix:

http://ci.wincontrail.codilime.com:8080/job/Wincontrail/job/test-integration/433/testReport/(root)/Contrail%20Network%20Driver%20test%20suite/On_requests_from_docker_daemon_on_CreateNetwork_request_with_different__invalid_options_subnet_doesn_t_exist_in_Contrail/

Note, that we use the following construction to wait for our serve goroutine to spin up:

```
	startedServing := make(chan interface{}, 1)
	go func() {
		startedServing <- 1
		h.Serve(d.listener)
	}()
	// wait for listener goroutine to spin up before moving on. Note: this is not entirely
	// thread safe, but I tried other ways to do it and was not successful.
	<-startedServing
```

which is NOT thread safe. Threads may switch in-between ```startedServing <- 1``` and ```h.Serve(d.listener)```.

Normally, the handler (```h``` in the above) should implement something like "is started" channel or method, but I don't feel like modifying even more 3rd party packages... This would involve modifying microsoft/go-winio and/or docker/go-plugins-helpers.

Also, we poll \\.\pipe\Contrail file if it was created. Sometimes we get "access denied" if a file doesn't exist yet. We also wait for the file to be removed after we close the pipe.

Moreover, we poll the pipe itself (by dialing), if we're waiting for it to start.

If docker knows about the driver, then it will keep the named pipe file open. This means that we can't really remove it between tests, which means we need to make sure docker shuts down cleanly each time.

Also, fixed a problem in go-winio.

All these methods in combinations seem to be robust enough.